### PR TITLE
fix underflow of `registers.nz`

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -362,6 +362,7 @@ func (sk *Sketch) UnmarshalBinary(data []byte) error {
 		if err != nil {
 			return err
 		}
+		newh.b = sk.b
 		*sk = *newh
 	}
 

--- a/registers.go
+++ b/registers.go
@@ -19,7 +19,7 @@ func (r *reg) set(offset, val uint8) bool {
 		tmpVal := uint8((*r) << 4 >> 4)
 		*r = reg(tmpVal | (val << 4))
 	} else {
-		isZero = *r > 15
+		isZero = *r&0x0f == 0
 		tmpVal := uint8((*r) >> 4 << 4)
 		*r = reg(tmpVal | val)
 	}

--- a/registers_test.go
+++ b/registers_test.go
@@ -52,3 +52,31 @@ func TestRegistersZeros(t *testing.T) {
 		t.Errorf("expected 1, got %d", got)
 	}
 }
+
+func assertRegistersNz(t *testing.T, rs *registers, nz uint32) {
+	t.Helper()
+	if rs.nz != nz {
+		t.Fatalf("registers.nz is not %d: actual=%d", nz, rs.nz)
+	}
+}
+
+func TestRegistersSetRepeatedly(t *testing.T) {
+	rs := newRegisters(16)
+
+	// count down nz when set non-zero values to each registers.
+	assertRegistersNz(t, rs, 16)
+	for i := uint32(0); i < 16; i++ {
+		rs.set(i, 1)
+		assertRegistersNz(t, rs, 15 - i)
+	}
+
+	// keep nz:0 when set non-zero values.
+	for i := uint8(1); i <= 15; i++ {
+		for j := uint32(0); j < 16; j++ {
+			rs.set(j, i)
+			if rs.nz != 0 {
+				t.Fatalf("registers.nz is not zero: actual=%d (i=%d, j=%d)", rs.nz, i, j)
+			}
+		}
+	}
+}

--- a/sparse_test.go
+++ b/sparse_test.go
@@ -1,0 +1,19 @@
+package hyperloglog
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestSparseEncodeDecode(t *testing.T) {
+	const p, pp = 14, 25
+	for i := 0; i < 1000000; i++ {
+		x := rand.Uint64()
+		k := encodeHash(x, p, pp)
+		idx1, rho1 := decodeHash(k, p, pp)
+		idx2, rho2 := getPosVal(x, p)
+		if uint64(idx1) != idx2 || rho1 != rho2 {
+			t.Fatalf("decode failure: i=%d x=%016x k=%08x idx1=%08x rho1=%02x idx2=%08x rho2=%02x", i, x, k, idx1, rho1, idx2, rho2)
+		}
+	}
+}


### PR DESCRIPTION
This PR includes:

* added a test for sparse encoder and decoder
* fixed `registers.nz` undlerflow
    * when this underflow occurred, base offset (`sk.b`) wouldn't increase anymore
    * `sk.b` was zero in most dense cases by this problem
* fixed that `sk.b` wasn't be unmarshalized when precision wasn't matched