### PR TITLE
prevent UnmarshalBinary() from panic when try to parse short bytes

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -81,6 +81,10 @@ func (v *compressedList) MarshalBinary() (data []byte, err error) {
 }
 
 func (v *compressedList) UnmarshalBinary(data []byte) error {
+	if len(data) < 12 {
+		return ErrorTooShort
+	}
+
 	// Set the count.
 	v.count, data = binary.BigEndian.Uint32(data[:4]), data[4:]
 
@@ -90,6 +94,9 @@ func (v *compressedList) UnmarshalBinary(data []byte) error {
 	// Set the list.
 	sz, data := binary.BigEndian.Uint32(data[:4]), data[4:]
 	v.b = make([]uint8, sz)
+	if uint32(len(data)) < sz {
+		return ErrorTooShort
+	}
 	for i := uint32(0); i < sz; i++ {
 		v.b[i] = data[i]
 	}

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -341,8 +341,16 @@ func (sk *Sketch) MarshalBinary() (data []byte, err error) {
 	return data, nil
 }
 
+// ErrorTooShort is an error that UnmarshalBinary try to parse too short
+// binary.
+var ErrorTooShort = errors.New("too short binary")
+
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
 func (sk *Sketch) UnmarshalBinary(data []byte) error {
+	if len(data) < 8 {
+		return ErrorTooShort
+	}
+
 	// Unmarshal version. We may need this in the future if we make
 	// non-compatible changes.
 	_ = data[0]

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -631,6 +631,30 @@ func TestHLLTC_Marshal_Unmarshal_Reuse(t *testing.T) {
 	}
 }
 
+func TestHLLTC_Unmarshal_ErrorTooShort(t *testing.T) {
+	if err := (&Sketch{}).UnmarshalBinary(nil); err != ErrorTooShort {
+		t.Fatalf("UnmarshalBinary(nil) should fail with ErrorTooShort: %s", err)
+	}
+
+	b := []byte{
+		// precision:14, sparse:true, tmpSet:empty,
+		// sparseList:{count:1, last:0, sz:1, ...}
+		0x01, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01, 0x7f,
+	}
+	if err := (&Sketch{}).UnmarshalBinary(b); err != nil {
+		t.Fatalf("UnmarshalBinary failed: %s", err)
+	}
+	for i := 0 ; i < len(b)-1; i++ {
+		sk := &Sketch{}
+		err := sk.UnmarshalBinary(b[0:i])
+		if err != ErrorTooShort {
+			t.Fatalf("should fail for incomplete bytes: i=%d", i)
+		}
+	}
+}
+
 func TestHLLTC_Clone(t *testing.T) {
 	sk1 := NewTestSketch(16)
 


### PR DESCRIPTION
Problem: package users feel inconvenience if `UnmarshalBinary()` causes `panic()` when given broken bytes which come from broken files or so. it is not easy to recover from panic for most of applications.

Solution: make `UnmarshalBinary()` checks input arguments, raise some errors.