### PR TITLE
Don't shadow new builtin function

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -35,32 +35,32 @@ func New() *Sketch {
 
 // New14 returns a HyperLogLog Sketch with 2^14 registers (precision 14)
 func New14() *Sketch {
-	sk, _ := new(14, true)
+	sk, _ := newSketch(14, true)
 	return sk
 }
 
 // New16 returns a HyperLogLog Sketch with 2^16 registers (precision 16)
 func New16() *Sketch {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	return sk
 }
 
 // NewNoSparse returns a HyperLogLog Sketch with 2^14 registers (precision 14)
 // that will not use a sparse representation
 func NewNoSparse() *Sketch {
-	sk, _ := new(14, false)
+	sk, _ := newSketch(14, false)
 	return sk
 }
 
 // New16NoSparse returns a HyperLogLog Sketch with 2^16 registers (precision 16)
 // that will not use a sparse representation
 func New16NoSparse() *Sketch {
-	sk, _ := new(16, false)
+	sk, _ := newSketch(16, false)
 	return sk
 }
 
-// new returns a HyperLogLog Sketch with 2^precision registers
-func new(precision uint8, sparse bool) (*Sketch, error) {
+// newSketch returns a HyperLogLog Sketch with 2^precision registers
+func newSketch(precision uint8, sparse bool) (*Sketch, error) {
 	if precision < 4 || precision > 18 {
 		return nil, fmt.Errorf("p has to be >= 4 and <= 18")
 	}
@@ -372,9 +372,9 @@ func (sk *Sketch) UnmarshalBinary(data []byte) error {
 	// Determine if we need a sparse Sketch
 	sparse := data[3] == byte(1)
 
-	// Make a new Sketch if the precision doesn't match or if the Sketch was used
+	// Make a newSketch Sketch if the precision doesn't match or if the Sketch was used
 	if sk.p != p || sk.regs != nil || len(sk.tmpSet) > 0 || (sk.sparseList != nil && sk.sparseList.Len() > 0) {
-		newh, err := new(p, sparse)
+		newh, err := newSketch(p, sparse)
 		if err != nil {
 			return err
 		}

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -30,7 +30,7 @@ func nopHash(buf []byte) uint64 {
 }
 
 func TestHLLTC_CardinalityHashed(t *testing.T) {
-	hlltc, err := new(14, true)
+	hlltc, err := newSketch(14, true)
 	if err != nil {
 		t.Error("expected no error, got", err)
 	}
@@ -117,7 +117,7 @@ func TestHLLTC_Precision_NoSparse(t *testing.T) {
 	defer func() {
 		hash = hashFunc
 	}()
-	sk, _ := new(4, false)
+	sk, _ := newSketch(4, false)
 
 	sk.Insert(toByte(0x1fffffffffffffff))
 	n := sk.regs.get(1)
@@ -295,8 +295,8 @@ func TestHLLTC_Merge_Sparse(t *testing.T) {
 }
 
 func TestHLLTC_Merge_Rebase(t *testing.T) {
-	sk1, _ := new(16, false)
-	sk2, _ := new(16, false)
+	sk1, _ := newSketch(16, false)
+	sk2, _ := newSketch(16, false)
 
 	sk1.regs.set(13, 7)
 	sk2.regs.set(13, 1)
@@ -338,15 +338,15 @@ func TestHLLTC_Merge_Rebase(t *testing.T) {
 }
 
 func TestHLLTC_Merge_Complex(t *testing.T) {
-	sk1, err := new(14, true)
+	sk1, err := newSketch(14, true)
 	if err != nil {
 		t.Error("expected no error, got", err)
 	}
-	sk2, err := new(14, true)
+	sk2, err := newSketch(14, true)
 	if err != nil {
 		t.Error("expected no error, got", err)
 	}
-	sk3, err := new(14, true)
+	sk3, err := newSketch(14, true)
 	if err != nil {
 		t.Error("expected no error, got", err)
 	}
@@ -452,24 +452,24 @@ func TestHLLTC_EncodeDecode(t *testing.T) {
 }
 
 func TestHLLTC_Error(t *testing.T) {
-	_, err := new(3, true)
+	_, err := newSketch(3, true)
 	if err == nil {
 		t.Error("precision 3 should return error")
 	}
 
-	_, err = new(18, true)
+	_, err = newSketch(18, true)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = new(19, true)
+	_, err = newSketch(19, true)
 	if err == nil {
 		t.Error("precision 19 should return error")
 	}
 }
 
 func TestHLLTC_Marshal_Unmarshal_Sparse(t *testing.T) {
-	sk, _ := new(4, true)
+	sk, _ := newSketch(4, true)
 	sk.sparse = true
 	sk.tmpSet = map[uint32]struct{}{26: {}, 40: {}}
 
@@ -501,7 +501,7 @@ func TestHLLTC_Marshal_Unmarshal_Sparse(t *testing.T) {
 }
 
 func TestHLLTC_Marshal_Unmarshal_Dense(t *testing.T) {
-	sk, _ := new(4, false)
+	sk, _ := newSketch(4, false)
 
 	// Add a bunch of values to the dense representation.
 	for i := uint32(0); i < 10; i++ {
@@ -538,7 +538,7 @@ func TestHLLTC_Marshal_Unmarshal_Count(t *testing.T) {
 	}
 
 	count := make(map[string]struct{}, 1000000)
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 
 	buf := make([]byte, 8)
 	for i := 0; i < 1000000; i++ {
@@ -598,7 +598,7 @@ func TestHLLTC_Marshal_Unmarshal_Count(t *testing.T) {
 
 // Tests that a sketch will be used in Unmarshal if it is unused
 func TestHLLTC_Marshal_Unmarshal_Reuse(t *testing.T) {
-	sk, _ := new(4, true)
+	sk, _ := newSketch(4, true)
 	// Add a bunch of values to the sparse representation.
 	for i := 0; i < 10; i++ {
 		sk.sparseList.Append(uint32(rand.Int()))
@@ -607,9 +607,9 @@ func TestHLLTC_Marshal_Unmarshal_Reuse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, _ := new(4, true)
+	res, _ := newSketch(4, true)
 	// Change the "m" here because it's not adjusted so it'll allow us to
-	// determine if new was called
+	// determine if newSketch was called
 	res.m = 1
 	if err := res.UnmarshalBinary(data); err != nil {
 		t.Fatal(err)
@@ -617,17 +617,17 @@ func TestHLLTC_Marshal_Unmarshal_Reuse(t *testing.T) {
 
 	// Compare the "m" to make sure it's the same
 	if res.m != 1 {
-		t.Fatalf("UnmarshalBinary created a new Sketch")
+		t.Fatalf("UnmarshalBinary created a newSketch Sketch")
 	}
 
-	// If we re-use the same sketch, new should be called
+	// If we re-use the same sketch, newSketch should be called
 	if err := res.UnmarshalBinary(data); err != nil {
 		t.Fatal(err)
 	}
 
 	// Compare the "m" to make sure it was changed
 	if res.m == 1 {
-		t.Fatalf("UnmarshalBinary did not create a new Sketch")
+		t.Fatalf("UnmarshalBinary did not create a newSketch Sketch")
 	}
 }
 
@@ -756,7 +756,7 @@ func isSketchEqual(sk1, sk2 *Sketch) bool {
 }
 
 func NewTestSketch(p uint8) *Sketch {
-	sk, _ := new(p, true)
+	sk, _ := newSketch(p, true)
 	return sk
 }
 
@@ -804,37 +804,37 @@ func benchmarkAdd(b *testing.B, sk *Sketch, n int) {
 }
 
 func Benchmark_Add_100(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 100)
 }
 
 func Benchmark_Add_1000(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 1000)
 }
 
 func Benchmark_Add_10000(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 10000)
 }
 
 func Benchmark_Add_100000(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 100000)
 }
 
 func Benchmark_Add_1000000(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 1000000)
 }
 
 func Benchmark_Add_10000000(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 10000000)
 }
 
 func Benchmark_Add_100000000(b *testing.B) {
-	sk, _ := new(16, true)
+	sk, _ := newSketch(16, true)
 	benchmarkAdd(b, sk, 100000000)
 }
 
@@ -844,7 +844,7 @@ func randStr(n int) string {
 }
 
 func benchmark(precision uint8, n int) {
-	hll, _ := new(precision, true)
+	hll, _ := newSketch(precision, true)
 
 	for i := 0; i < n; i++ {
 		s := []byte(randStr(i))


### PR DESCRIPTION
Rename `new` -> `newSkecth`. This avoids shadowing
of the `new` builtin function.

This is a small cosmetic change, however it makes
reading code easier for anyone new to the project.
I find that Go programmers are generally expecting
`new` to be the builtin function. Having it shadowed
is confusing.