### PR TITLE
Reduce size of sparse representation

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -103,9 +103,9 @@ func (v *compressedList) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func newCompressedList(size int) *compressedList {
+func newCompressedList() *compressedList {
 	v := &compressedList{}
-	v.b = make(variableLengthList, 0, size)
+	v.b = make(variableLengthList, 0)
 	return v
 }
 

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -73,7 +73,7 @@ func new(precision uint8, sparse bool) (*Sketch, error) {
 	if sparse {
 		s.sparse = true
 		s.tmpSet = set{}
-		s.sparseList = newCompressedList(int(m))
+		s.sparseList = newCompressedList()
 	} else {
 		s.regs = newRegisters(m)
 	}
@@ -272,7 +272,7 @@ func (sk *Sketch) mergeSparse() {
 	}
 	sort.Sort(keys)
 
-	newList := newCompressedList(int(sk.m))
+	newList := newCompressedList()
 	for iter, i := sk.sparseList.Iter(), 0; iter.HasNext() || i < len(keys); {
 		if !iter.HasNext() {
 			newList.Append(keys[i])

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -646,7 +646,7 @@ func TestHLLTC_Unmarshal_ErrorTooShort(t *testing.T) {
 	if err := (&Sketch{}).UnmarshalBinary(b); err != nil {
 		t.Fatalf("UnmarshalBinary failed: %s", err)
 	}
-	for i := 0 ; i < len(b)-1; i++ {
+	for i := 0; i < len(b)-1; i++ {
 		sk := &Sketch{}
 		err := sk.UnmarshalBinary(b[0:i])
 		if err != ErrorTooShort {
@@ -801,6 +801,16 @@ func benchmarkAdd(b *testing.B, sk *Sketch, n int) {
 		}
 	}
 	b.StopTimer()
+}
+
+// Report size and allocations of a new sparse HLL
+func Benchmark_Size_New_Sparse(b *testing.B) {
+	var sk *Sketch
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sk, _ = new(16, true)
+	}
+	_ = sk
 }
 
 func Benchmark_Add_100(b *testing.B) {


### PR DESCRIPTION
Reduce size of sparse representation by not preallocating the
compressed list's `variableLengthList`.

I think this is the right trade-off to make. The sparse
representation is intended to save memory. Preallocating
the whole buffer ruins that.

Consider a HLL of precision 16:
```
Benchmark_Size_New_Sparse-8   	  210655	      6247 ns/op	   65664 B/op	       4 allocs/op
```
with change:
```
Benchmark_Size_New_Sparse-8   	 7066699	       172 ns/op	     128 B/op	       3 allocs/op
```

Resolves #21