### PR TITLE
Add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            go get gotest.tools/gotestsum@v0.4.0
+            mkdir -p test-results/gotestsum
+            gotestsum --junitfile test-results/gotestsum/results.xml -f short-verbose -- ./...
+      - run: 
+          name: Run benchmarks
+          command: go test -bench .
+      - store_test_results:
+          path: test-results

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   ---
 
-[![GoDoc](https://godoc.org/github.com/axiomhq/hyperloglog?status.svg)](https://godoc.org/github.com/axiomhq/hyperloglog) [![Go Report Card](https://goreportcard.com/badge/github.com/axiomhq/hyperloglog)](https://goreportcard.com/report/github.com/axiomhq/hyperloglog)
+[![GoDoc](https://godoc.org/github.com/axiomhq/hyperloglog?status.svg)](https://godoc.org/github.com/axiomhq/hyperloglog) [![Go Report Card](https://goreportcard.com/badge/github.com/axiomhq/hyperloglog)](https://goreportcard.com/report/github.com/axiomhq/hyperloglog) [![CircleCI](https://circleci.com/gh/axiomhq/hyperloglog/tree/master.svg?style=svg)](https://circleci.com/gh/axiomhq/hyperloglog/tree/master)
 
 An improved version of [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog) for the count-distinct problem, approximating the number of distinct elements in a multiset **using 33-50% less space** than other usual HyperLogLog implementations.
 


### PR DESCRIPTION
This configure CircleCI and runs tests and benchmarks on every push. It collects test-results with `gotestsum` to show a summary.

It also adds a badge showing the build status of `master`.

[![Screenshot 2019-11-12 at 14 08 06](https://user-images.githubusercontent.com/1725839/68674289-dd37c480-0555-11ea-974f-5011fbf5b094.png)](https://circleci.com/gh/bahlo/hyperloglog/18)

Before merging this, please go to [Add Projects](https://circleci.com/add-projects/gh/axiomhq) on CircleCI and click `Set Up Project` next to this project, then `Start Building`.