### PR TITLE
Fixed genData function in tests

### DIFF
--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -772,8 +772,10 @@ func genData(num int) [][]byte {
 		} else if n != 8 {
 			panic(fmt.Errorf("only %d bytes generated", n))
 		}
-
-		out = append(out, buf)
+		
+		copiedBuf := make([]byte, 8)	
+		copy(copiedBuf, buf)  // copy the contents of buf to copiedBuf
+		out = append(out, copiedBuf)
 	}
 	if len(out) != num {
 		panic(fmt.Sprintf("wrong size slice: %d", num))


### PR DESCRIPTION
Before it was adding the same buf to slice. 
Since slices are references to underlying arrays, all the slices in out were actually pointing to the same buf slice. Any subsequent modification to buf affected all the slices stored in out.