### PR TITLE
refactor: address issues in test and enhance memory efficiency in com…

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -103,9 +103,9 @@ func (v *compressedList) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func newCompressedList() *compressedList {
+func newCompressedList(capacity int) *compressedList {
 	v := &compressedList{}
-	v.b = make(variableLengthList, 0)
+	v.b = make(variableLengthList, 0, capacity)
 	return v
 }
 

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -71,7 +71,7 @@ func newSketch(precision uint8, sparse bool) (*Sketch, error) {
 	}
 	if sparse {
 		s.tmpSet = set{}
-		s.sparseList = newCompressedList()
+		s.sparseList = newCompressedList(0)
 	} else {
 		s.regs = newRegisters(m)
 	}
@@ -253,9 +253,9 @@ func (sk *Sketch) Estimate() uint64 {
 	}
 
 	if sk.b == 0 {
-		est = (sk.alpha * m * (m - ez) / (sum + beta(ez)))
+		est = sk.alpha * m * (m - ez) / (sum + beta(ez))
 	} else {
-		est = (sk.alpha * m * m / sum)
+		est = sk.alpha * m * m / sum
 	}
 
 	return uint64(est + 0.5)
@@ -272,7 +272,7 @@ func (sk *Sketch) mergeSparse() {
 	}
 	sort.Sort(keys)
 
-	newList := newCompressedList()
+	newList := newCompressedList(4*len(sk.tmpSet) + len(sk.sparseList.b))
 	for iter, i := sk.sparseList.Iter(), 0; iter.HasNext() || i < len(keys); {
 		if !iter.HasNext() {
 			newList.Append(keys[i])

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -761,19 +761,20 @@ func NewTestSketch(p uint8) *Sketch {
 
 // Generate random data to add to the sketch.
 func genData(num int) [][]byte {
-	out := make([][]byte, 0, num)
+	out := make([][]byte, num)
 	buf := make([]byte, 8)
 
 	for i := 0; i < num; i++ {
 		// generate 8 random bytes
-		n, err := rand.Read(buf)
+		n, err := crand.Read(buf)
 		if err != nil {
 			panic(err)
 		} else if n != 8 {
 			panic(fmt.Errorf("only %d bytes generated", n))
 		}
 
-		out = append(out, buf)
+		out[i] = make([]byte, 8)
+		copy(out[i], buf)
 	}
 	if len(out) != num {
 		panic(fmt.Sprintf("wrong size slice: %d", num))


### PR DESCRIPTION
…pressedList initialization

1. Fix issue in test: Avoid copying the address of buf in tests, preventing the generated arrays from pointing to the same address.

2. Enhance compressedList initialization: Introduce a capacity parameter during initialization to reduce memory allocation overhead during the mergeSparse process.

related issue: https://github.com/axiomhq/hyperloglog/issues/37