### PR TITLE
Improve set operation speeds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/axiomhq/hyperloglog
 
-go 1.21
+go 1.23
 
-toolchain go1.23.0
+toolchain go1.23.4
 
 require (
 	github.com/davecgh/go-spew v1.1.1
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/kamstrup/intmap v0.5.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/kamstrup/intmap v0.5.0 h1:WY7OJQeG7Ujc9zpPTO6PraDGSveG9js9wCPoI2q8wJQ=
+github.com/kamstrup/intmap v0.5.0/go.mod h1:gWUVWHKzWj8xpJVFf5GC0O26bWmv3GqdnIX/LMT6Aq4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/sparse.go
+++ b/sparse.go
@@ -2,6 +2,8 @@ package hyperloglog
 
 import (
 	"math/bits"
+
+	"github.com/kamstrup/intmap"
 )
 
 func getIndex(k uint32, p, pp uint8) uint32 {
@@ -34,37 +36,61 @@ func decodeHash(k uint32, p, pp uint8) (uint32, uint8) {
 	return getIndex(k, p, pp), r
 }
 
-type set map[uint32]struct{}
+type set struct {
+	m *intmap.Set[uint32]
+}
 
-func (s set) add(v uint32) bool {
-	_, ok := s[v]
-	if ok {
+func newSet(size int) *set {
+	return &set{m: intmap.NewSet[uint32](size)}
+}
+
+func (s *set) ForEach(fn func(v uint32)) {
+	s.m.ForEach(func(v uint32) bool {
+		fn(v)
+		return true
+	})
+}
+
+func (s *set) Merge(other *set) {
+	other.m.ForEach(func(v uint32) bool {
+		s.m.Add(v)
+		return true
+	})
+}
+
+func (s *set) Len() int {
+	return s.m.Len()
+}
+
+func (s *set) add(v uint32) bool {
+	if s.m.Has(v) {
 		return false
 	}
-	s[v] = struct{}{}
+	s.m.Add(v)
 	return true
 }
 
-func (s set) Clone() set {
+func (s *set) Clone() *set {
 	if s == nil {
 		return nil
 	}
 
-	newS := make(map[uint32]struct{}, len(s))
-	for k, v := range s {
-		newS[k] = v
-	}
-	return newS
+	newS := intmap.NewSet[uint32](s.m.Len())
+	s.m.ForEach(func(v uint32) bool {
+		newS.Add(v)
+		return true
+	})
+	return &set{m: newS}
 }
 
-func (s set) MarshalBinary() (data []byte, err error) {
+func (s *set) MarshalBinary() (data []byte, err error) {
 	// 4 bytes for the size of the set, and 4 bytes for each key.
 	// list.
-	data = make([]byte, 0, 4+(4*len(s)))
+	data = make([]byte, 0, 4+(4*s.m.Len()))
 
 	// Length of the set. We only need 32 bits because the size of the set
 	// couldn't exceed that on 32 bit architectures.
-	sl := len(s)
+	sl := s.m.Len()
 	data = append(data, []byte{
 		byte(sl >> 24),
 		byte(sl >> 16),
@@ -73,14 +99,15 @@ func (s set) MarshalBinary() (data []byte, err error) {
 	}...)
 
 	// Marshal each element in the set.
-	for k := range s {
+	s.m.ForEach(func(k uint32) bool {
 		data = append(data, []byte{
 			byte(k >> 24),
 			byte(k >> 16),
 			byte(k >> 8),
 			byte(k),
 		}...)
-	}
+		return true
+	})
 
 	return data, nil
 }


### PR DESCRIPTION
use intmap.Set instead of map[uint32]struct for set

```
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/axiomhq/hyperloglog
cpu: Apple M3 Max
                                      │    old.txt    │               new.txt               │
                                      │    sec/op     │    sec/op     vs base               │
_Merge/size1=100/size2=100-16           17.976µ ± ∞ ¹   7.794µ ± ∞ ¹  -56.64% (p=0.008 n=5)
_Merge/size1=100/size2=10000-16          31.91µ ± ∞ ¹   26.78µ ± ∞ ¹  -16.08% (p=0.008 n=5)
_Merge/size1=100/size2=1000000-16        16.70µ ± ∞ ¹   11.86µ ± ∞ ¹  -29.00% (p=0.008 n=5)
_Merge/size1=10000/size2=100-16          22.21µ ± ∞ ¹   23.00µ ± ∞ ¹        ~ (p=0.548 n=5)
_Merge/size1=10000/size2=10000-16        61.63µ ± ∞ ¹   60.64µ ± ∞ ¹   -1.60% (p=0.008 n=5)
_Merge/size1=10000/size2=1000000-16      34.78µ ± ∞ ¹   33.31µ ± ∞ ¹        ~ (p=0.222 n=5)
_Merge/size1=1000000/size2=100-16        8.316µ ± ∞ ¹   7.948µ ± ∞ ¹   -4.43% (p=0.008 n=5)
_Merge/size1=1000000/size2=10000-16      14.68µ ± ∞ ¹   14.38µ ± ∞ ¹   -2.05% (p=0.008 n=5)
_Merge/size1=1000000/size2=1000000-16    29.66µ ± ∞ ¹   29.03µ ± ∞ ¹        ~ (p=0.548 n=5)
geomean                                  22.78µ         19.36µ        -15.02%
¹ need >= 6 samples for confidence interval at level 0.95

                                      │    old.txt    │                new.txt                │
                                      │     B/op      │      B/op       vs base               │
_Merge/size1=100/size2=100-16           5.847Ki ± ∞ ¹   10.008Ki ± ∞ ¹  +71.17% (p=0.008 n=5)
_Merge/size1=100/size2=10000-16         18.96Ki ± ∞ ¹    21.07Ki ± ∞ ¹  +11.16% (p=0.008 n=5)
_Merge/size1=100/size2=1000000-16       18.96Ki ± ∞ ¹    21.07Ki ± ∞ ¹  +11.16% (p=0.008 n=5)
_Merge/size1=10000/size2=100-16         16.14Ki ± ∞ ¹    16.16Ki ± ∞ ¹   +0.15% (p=0.008 n=5)
_Merge/size1=10000/size2=10000-16       16.14Ki ± ∞ ¹    16.16Ki ± ∞ ¹   +0.15% (p=0.008 n=5)
_Merge/size1=10000/size2=1000000-16     16.14Ki ± ∞ ¹    16.16Ki ± ∞ ¹   +0.15% (p=0.008 n=5)
_Merge/size1=1000000/size2=100-16       16.14Ki ± ∞ ¹    16.16Ki ± ∞ ¹   +0.15% (p=0.008 n=5)
_Merge/size1=1000000/size2=10000-16     16.14Ki ± ∞ ¹    16.16Ki ± ∞ ¹   +0.15% (p=0.008 n=5)
_Merge/size1=1000000/size2=1000000-16   16.14Ki ± ∞ ¹    16.16Ki ± ∞ ¹   +0.15% (p=0.008 n=5)
geomean                                 14.94Ki          16.26Ki         +8.78%
¹ need >= 6 samples for confidence interval at level 0.95

                                      │   old.txt   │              new.txt               │
                                      │  allocs/op  │  allocs/op   vs base               │
_Merge/size1=100/size2=100-16           32.00 ± ∞ ¹   20.00 ± ∞ ¹  -37.50% (p=0.008 n=5)
_Merge/size1=100/size2=10000-16         26.00 ± ∞ ¹   20.00 ± ∞ ¹  -23.08% (p=0.008 n=5)
_Merge/size1=100/size2=1000000-16       26.00 ± ∞ ¹   20.00 ± ∞ ¹  -23.08% (p=0.008 n=5)
_Merge/size1=10000/size2=100-16         4.000 ± ∞ ¹   6.000 ± ∞ ¹  +50.00% (p=0.008 n=5)
_Merge/size1=10000/size2=10000-16       4.000 ± ∞ ¹   6.000 ± ∞ ¹  +50.00% (p=0.008 n=5)
_Merge/size1=10000/size2=1000000-16     4.000 ± ∞ ¹   6.000 ± ∞ ¹  +50.00% (p=0.008 n=5)
_Merge/size1=1000000/size2=100-16       4.000 ± ∞ ¹   6.000 ± ∞ ¹  +50.00% (p=0.008 n=5)
_Merge/size1=1000000/size2=10000-16     4.000 ± ∞ ¹   6.000 ± ∞ ¹  +50.00% (p=0.008 n=5)
_Merge/size1=1000000/size2=1000000-16   4.000 ± ∞ ¹   6.000 ± ∞ ¹  +50.00% (p=0.008 n=5)
geomean                                 7.639         8.963        +17.33%
¹ need >= 6 samples for confidence interval at level 0.95
```