### PR TITLE
chore: reorganize comments in docs-friendly way

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -24,11 +24,20 @@ type Sketch struct {
 	regs       []uint8
 }
 
-func New() *Sketch           { return New14() }                     // New returns a HyperLogLog Sketch with 2^14 registers (precision 14)
-func New14() *Sketch         { return newSketchNoError(14, true) }  // New14 returns a HyperLogLog Sketch with 2^14 registers (precision 14)
-func New16() *Sketch         { return newSketchNoError(16, true) }  // New16 returns a HyperLogLog Sketch with 2^16 registers (precision 16)
-func NewNoSparse() *Sketch   { return newSketchNoError(14, false) } // NewNoSparse returns a HyperLogLog Sketch with 2^14 registers (precision 14) that will not use a sparse representation
-func New16NoSparse() *Sketch { return newSketchNoError(16, false) } // New16NoSparse returns a HyperLogLog Sketch with 2^16 registers (precision 16) that will not use a sparse representation
+// New returns a HyperLogLog Sketch with 2^14 registers (precision 14)
+func New() *Sketch { return New14() }
+
+// New14 returns a HyperLogLog Sketch with 2^14 registers (precision 14)
+func New14() *Sketch { return newSketchNoError(14, true) }
+
+// New16 returns a HyperLogLog Sketch with 2^16 registers (precision 16)
+func New16() *Sketch { return newSketchNoError(16, true) }
+
+// NewNoSparse returns a HyperLogLog Sketch with 2^14 registers (precision 14) that will not use a sparse representation
+func NewNoSparse() *Sketch { return newSketchNoError(14, false) }
+
+// New16NoSparse returns a HyperLogLog Sketch with 2^16 registers (precision 16) that will not use a sparse representation
+func New16NoSparse() *Sketch { return newSketchNoError(16, false) }
 
 func newSketchNoError(precision uint8, sparse bool) *Sketch {
 	sk, _ := NewSketch(precision, sparse)


### PR DESCRIPTION
Hello! I'm new to this library and have a small suggestion to improve it.

Currently, it seems difficult to find useful information on initializing a HyperLogLog sketch from the reference.

It would be great if some comments could be reorganized in a more docs-friendly way.

### AS-IS

<img width="575" alt="스크린샷 2025-01-10 오후 12 07 06" src="https://github.com/user-attachments/assets/efe25e04-f754-4304-98a7-ce64c43d1128" />

### TO-BE

<img width="798" alt="스크린샷 2025-01-10 오후 12 04 50" src="https://github.com/user-attachments/assets/ae6e5857-baae-41d7-952c-24611d74390d" />
