### PR TITLE
assorted optimizations

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -6,16 +6,11 @@ import (
 )
 
 // Original author of this file is github.com/clarkduvall/hyperloglog
-type iterable interface {
-	decode(i int, last uint32) (uint32, int)
-	Len() int
-	Iter() *iterator
-}
 
 type iterator struct {
 	i    int
 	last uint32
-	v    iterable
+	v    *compressedList
 }
 
 func (iter *iterator) Next() uint32 {
@@ -125,8 +120,8 @@ func (v *compressedList) Append(x uint32) {
 	v.last = x
 }
 
-func (v *compressedList) Iter() *iterator {
-	return &iterator{0, 0, v}
+func (v *compressedList) Iter() iterator {
+	return iterator{0, 0, v}
 }
 
 type variableLengthList []uint8
@@ -134,11 +129,11 @@ type variableLengthList []uint8
 func (v variableLengthList) AppendBinary(data []byte) ([]byte, error) {
 	// 4 bytes for the size of the list, and a byte for each element in the
 	// list.
-	data = slices.Grow(data, 4+v.Len())
+	data = slices.Grow(data, 4+len(v))
 
 	// Length of the list. We only need 32 bits because the size of the set
 	// couldn't exceed that on 32 bit architectures.
-	sz := v.Len()
+	sz := len(v)
 	data = append(data,
 		byte(sz>>24),
 		byte(sz>>16),
@@ -152,14 +147,6 @@ func (v variableLengthList) AppendBinary(data []byte) ([]byte, error) {
 	}
 
 	return data, nil
-}
-
-func (v variableLengthList) Len() int {
-	return len(v)
-}
-
-func (v *variableLengthList) Iter() *iterator {
-	return &iterator{0, 0, v}
 }
 
 func (v variableLengthList) decode(i int, last uint32) (uint32, int) {

--- a/compressed.go
+++ b/compressed.go
@@ -25,9 +25,13 @@ func (iter *iterator) Next() uint32 {
 	return n
 }
 
-func (iter *iterator) Peek() uint32 {
-	n, _ := iter.v.decode(iter.i, iter.last)
-	return n
+func (iter *iterator) Peek() (uint32, int) {
+	return iter.v.decode(iter.i, iter.last)
+}
+
+func (iter *iterator) Advance(last uint32, i int) {
+	iter.last = last
+	iter.i = i
 }
 
 func (iter iterator) HasNext() bool {

--- a/compressed.go
+++ b/compressed.go
@@ -149,7 +149,7 @@ func (v variableLengthList) AppendBinary(data []byte) ([]byte, error) {
 	return data, nil
 }
 
-func (v variableLengthList) decode(i int, last uint32) (uint32, int) {
+func (v variableLengthList) decode(i int) (uint32, int) {
 	var x uint32
 	j := i
 	for ; v[j]&0x80 != 0; j++ {

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 )
 
 const (
@@ -177,11 +176,11 @@ func (sk *Sketch) mergeSparse() {
 		return
 	}
 
-	keys := make(uint64Slice, 0, sk.tmpSet.Len())
+	keys := make([]uint32, 0, sk.tmpSet.Len())
 	sk.tmpSet.ForEach(func(k uint32) {
 		keys = append(keys, k)
 	})
-	sort.Sort(keys)
+	slices.Sort(keys)
 
 	newList := newCompressedList(4*sk.tmpSet.Len() + sk.sparseList.Len())
 	for iter, i := sk.sparseList.Iter(), 0; iter.HasNext() || i < len(keys); {

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -195,15 +195,18 @@ func (sk *Sketch) mergeSparse() {
 			continue
 		}
 
-		x1, x2 := iter.Peek(), keys[i]
+		x1, adv := iter.Peek()
+		x2 := keys[i]
 		if x1 == x2 {
-			newList.Append(iter.Next())
+			newList.Append(x1)
+			iter.Advance(x1, adv)
 			i++
 		} else if x1 > x2 {
 			newList.Append(x2)
 			i++
 		} else {
-			newList.Append(iter.Next())
+			newList.Append(x1)
+			iter.Advance(x1, adv)
 		}
 	}
 

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -18,7 +18,7 @@ type Sketch struct {
 	p          uint8
 	m          uint32
 	alpha      float64
-	tmpSet     *set
+	tmpSet     set
 	sparseList *compressedList
 	regs       []uint8
 }
@@ -54,7 +54,7 @@ func NewSketch(precision uint8, sparse bool) (*Sketch, error) {
 		alpha: alpha(float64(m)),
 	}
 	if sparse {
-		s.tmpSet = newSet(0)
+		s.tmpSet = makeSet(0)
 		s.sparseList = newCompressedList(0)
 	} else {
 		s.regs = make([]uint8, m)
@@ -140,7 +140,7 @@ func (sk *Sketch) toNormal() {
 		sk.insert(i, r)
 	}
 
-	sk.tmpSet = nil
+	sk.tmpSet = nilSet
 	sk.sparseList = nil
 }
 
@@ -211,7 +211,7 @@ func (sk *Sketch) mergeSparse() {
 	}
 
 	sk.sparseList = newList
-	sk.tmpSet = newSet(0)
+	sk.tmpSet = makeSet(0)
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
@@ -305,7 +305,7 @@ func (sk *Sketch) UnmarshalBinary(data []byte) error {
 
 		// Unmarshal the tmp_set.
 		tssz := binary.BigEndian.Uint32(data[4:8])
-		sk.tmpSet = newSet(int(tssz))
+		sk.tmpSet = makeSet(int(tssz))
 
 		// We need to unmarshal tssz values in total, and each value requires us
 		// to read 4 bytes.
@@ -321,7 +321,7 @@ func (sk *Sketch) UnmarshalBinary(data []byte) error {
 
 	// Using the dense Sketch.
 	sk.sparseList = nil
-	sk.tmpSet = nil
+	sk.tmpSet = nilSet
 
 	if v == 1 {
 		return sk.unmarshalBinaryV1(data[8:], b)

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -617,23 +617,22 @@ func NewTestSketch(p uint8) *Sketch {
 
 // Generate random data to add to the sketch.
 func genData(num int) [][]byte {
-	out := make([][]byte, 0, num)
-	buf := make([]byte, 8)
+	const dataLen = 8
+	out := make([][]byte, num)
+	numBytes := dataLen * num
+	buf := make([]byte, numBytes)
 
-	for i := 0; i < num; i++ {
-		// generate 8 random bytes
-		n, err := crand.Read(buf)
-		if err != nil {
-			panic(err)
-		} else if n != 8 {
-			panic(fmt.Errorf("only %d bytes generated", n))
-		}
-		copiedBuf := make([]byte, 8)
-		copy(copiedBuf, buf) // copy the contents of buf to copiedBuf
-		out = append(out, copiedBuf)
+	// generate random bytes
+	n, err := crand.Read(buf)
+	if err != nil {
+		panic(err)
+	} else if n != numBytes {
+		panic(fmt.Errorf("only %d bytes generated, expected %d", n, numBytes))
 	}
-	if len(out) != num {
-		panic(fmt.Sprintf("wrong size slice: %d", num))
+
+	for i := range out {
+		out[i] = buf[:dataLen]
+		buf = buf[dataLen:]
 	}
 	return out
 }

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -318,7 +318,7 @@ func TestHLL_Error(t *testing.T) {
 
 func TestHLL_Marshal_Unmarshal_Sparse(t *testing.T) {
 	sk, _ := NewSketch(4, true)
-	sk.tmpSet = newSet(2)
+	sk.tmpSet = makeSet(2)
 	sk.tmpSet.add(26)
 	sk.tmpSet.add(40)
 

--- a/sparse.go
+++ b/sparse.go
@@ -64,11 +64,7 @@ func (s *set) Len() int {
 }
 
 func (s *set) add(v uint32) bool {
-	if s.m.Has(v) {
-		return false
-	}
-	s.m.Add(v)
-	return true
+	return s.m.Add(v)
 }
 
 func (s *set) Clone() *set {

--- a/sparse.go
+++ b/sparse.go
@@ -41,35 +41,37 @@ type set struct {
 	m *intmap.Set[uint32]
 }
 
-func newSet(size int) *set {
-	return &set{m: intmap.NewSet[uint32](size)}
+var nilSet set
+
+func makeSet(size int) set {
+	return set{m: intmap.NewSet[uint32](size)}
 }
 
-func (s *set) ForEach(fn func(v uint32)) {
+func (s set) ForEach(fn func(v uint32)) {
 	s.m.ForEach(func(v uint32) bool {
 		fn(v)
 		return true
 	})
 }
 
-func (s *set) Merge(other *set) {
+func (s set) Merge(other set) {
 	other.m.ForEach(func(v uint32) bool {
 		s.m.Add(v)
 		return true
 	})
 }
 
-func (s *set) Len() int {
+func (s set) Len() int {
 	return s.m.Len()
 }
 
-func (s *set) add(v uint32) bool {
+func (s set) add(v uint32) bool {
 	return s.m.Add(v)
 }
 
-func (s *set) Clone() *set {
-	if s == nil {
-		return nil
+func (s set) Clone() set {
+	if s == nilSet {
+		return nilSet
 	}
 
 	newS := intmap.NewSet[uint32](s.m.Len())
@@ -77,7 +79,7 @@ func (s *set) Clone() *set {
 		newS.Add(v)
 		return true
 	})
-	return &set{m: newS}
+	return set{m: newS}
 }
 
 func (s *set) AppendBinary(data []byte) ([]byte, error) {

--- a/sparse.go
+++ b/sparse.go
@@ -108,9 +108,3 @@ func (s *set) AppendBinary(data []byte) ([]byte, error) {
 
 	return data, nil
 }
-
-type uint64Slice []uint32
-
-func (p uint64Slice) Len() int           { return len(p) }
-func (p uint64Slice) Less(i, j int) bool { return p[i] < p[j] }
-func (p uint64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }


### PR DESCRIPTION
See the commit messages for details and `Benchmark_Add` comparisons between each commit.

Before/after of `Benchmark_Add` with all commits:

```
name               old time/op    new time/op    delta
_Add_100-10          1.20µs ± 0%    1.08µs ± 0%   -9.59%  (p=0.000 n=9+10)
_Add_1000-10          123µs ± 1%      90µs ± 0%  -26.78%  (p=0.000 n=10+9)
_Add_10000-10        2.56ms ± 0%    1.76ms ± 0%  -31.19%  (p=0.000 n=9+9)
_Add_100000-10        630µs ± 0%     627µs ± 0%   -0.43%  (p=0.000 n=9+10)
_Add_1000000-10      6.36ms ± 1%    6.27ms ± 0%   -1.30%  (p=0.000 n=10+9)
_Add_10000000-10     63.6ms ± 1%    62.9ms ± 0%   -1.12%  (p=0.001 n=8+9)
_Add_100000000-10     636ms ± 1%     628ms ± 0%   -1.22%  (p=0.000 n=9+9)

name               old alloc/op   new alloc/op   delta
_Add_100-10           0.00B          0.00B          ~     (all equal)
_Add_1000-10         38.6kB ± 0%    38.5kB ± 0%   -0.12%  (p=0.000 n=9+9)
_Add_10000-10         666kB ± 0%     666kB ± 0%   -0.06%  (p=0.000 n=10+10)
_Add_100000-10       1.92kB ± 0%    1.80kB ± 0%   -6.22%  (p=0.000 n=7+10)
_Add_1000000-10      16.7kB ± 2%    16.3kB ± 0%   -2.43%  (p=0.000 n=10+9)
_Add_10000000-10      171kB ± 0%     192kB ± 0%  +12.44%  (p=0.000 n=8+10)
_Add_100000000-10    1.54MB ± 0%    1.54MB ± 0%   -0.05%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
_Add_100-10            0.00           0.00          ~     (all equal)
_Add_1000-10           24.0 ± 0%      21.0 ± 0%  -12.50%  (p=0.000 n=10+10)
_Add_10000-10           243 ± 0%       213 ± 0%  -12.35%  (p=0.000 n=10+10)
_Add_100000-10         0.00           0.00          ~     (all equal)
_Add_1000000-10        4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.000 n=10+9)
_Add_10000000-10       46.0 ± 0%      45.0 ± 0%   -2.17%  (p=0.002 n=8+10)
_Add_100000000-10       416 ± 0%       364 ± 0%  -12.50%  (p=0.000 n=10+10)
```

Before/after of `Benchmark_Merge` with all commits:

```
name                                   old time/op    new time/op    delta
_Merge/size1=100/size2=100-10            9.62µs ± 1%    6.66µs ± 1%  -30.73%  (p=0.000 n=8+9)
_Merge/size1=100/size2=10000-10          54.8µs ± 1%    51.8µs ± 1%   -5.53%  (p=0.000 n=10+8)
_Merge/size1=100/size2=1000000-10        15.9µs ± 0%    14.5µs ± 1%   -8.66%  (p=0.000 n=8+9)
_Merge/size1=10000/size2=100-10          51.1µs ± 5%    50.4µs ± 2%     ~     (p=0.315 n=10+10)
_Merge/size1=10000/size2=10000-10         101µs ± 3%     101µs ± 4%     ~     (p=0.579 n=10+10)
_Merge/size1=10000/size2=1000000-10      61.8µs ± 2%    61.6µs ± 2%     ~     (p=0.579 n=10+10)
_Merge/size1=1000000/size2=100-10        11.1µs ± 1%    11.0µs ± 2%     ~     (p=0.063 n=10+10)
_Merge/size1=1000000/size2=10000-10      19.7µs ± 2%    19.5µs ± 0%   -1.31%  (p=0.000 n=9+10)
_Merge/size1=1000000/size2=1000000-10    56.8µs ± 3%    56.0µs ± 2%   -1.34%  (p=0.017 n=9+10)

name                                   old alloc/op   new alloc/op   delta
_Merge/size1=100/size2=100-10            10.2kB ± 0%    10.2kB ± 0%   -0.39%  (p=0.000 n=10+10)
_Merge/size1=100/size2=10000-10          21.6kB ± 0%    21.5kB ± 0%   -0.19%  (p=0.000 n=10+10)
_Merge/size1=100/size2=1000000-10        21.6kB ± 0%    21.5kB ± 0%   -0.19%  (p=0.000 n=10+10)
_Merge/size1=10000/size2=100-10          16.6kB ± 0%    16.5kB ± 0%   -0.05%  (p=0.000 n=10+10)
_Merge/size1=10000/size2=10000-10        16.6kB ± 0%    16.5kB ± 0%   -0.05%  (p=0.000 n=10+10)
_Merge/size1=10000/size2=1000000-10      16.6kB ± 0%    16.5kB ± 0%   -0.05%  (p=0.000 n=10+10)
_Merge/size1=1000000/size2=100-10        16.6kB ± 0%    16.5kB ± 0%   -0.05%  (p=0.000 n=10+10)
_Merge/size1=1000000/size2=10000-10      16.6kB ± 0%    16.5kB ± 0%   -0.05%  (p=0.000 n=10+10)
_Merge/size1=1000000/size2=1000000-10    16.6kB ± 0%    16.5kB ± 0%   -0.05%  (p=0.000 n=10+10)

name                                   old allocs/op  new allocs/op  delta
_Merge/size1=100/size2=100-10              20.0 ± 0%      17.0 ± 0%  -15.00%  (p=0.000 n=10+10)
_Merge/size1=100/size2=10000-10            20.0 ± 0%      17.0 ± 0%  -15.00%  (p=0.000 n=10+10)
_Merge/size1=100/size2=1000000-10          20.0 ± 0%      17.0 ± 0%  -15.00%  (p=0.000 n=10+10)
_Merge/size1=10000/size2=100-10            6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
_Merge/size1=10000/size2=10000-10          6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
_Merge/size1=10000/size2=1000000-10        6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
_Merge/size1=1000000/size2=100-10          6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
_Merge/size1=1000000/size2=10000-10        6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
_Merge/size1=1000000/size2=1000000-10      6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
```