### PR TITLE
Fix incorrect call to the decode method

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -110,7 +110,7 @@ func (v *compressedList) Len() int {
 }
 
 func (v *compressedList) decode(i int, last uint32) (uint32, int) {
-	n, i := v.b.decode(i, last)
+	n, i := v.b.decode(i)
 	return n + last, i
 }
 


### PR DESCRIPTION
The latest bug fix version `v0.2.4` is broken due to compile error. The PR fixes the compile error.