### PR TITLE
Adjust call to decode() for parameter change

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -110,7 +110,7 @@ func (v *compressedList) Len() int {
 }
 
 func (v *compressedList) decode(i int, last uint32) (uint32, int) {
-	n, i := v.b.decode(i, last)
+	n, i := v.b.decode(i)
 	return n + last, i
 }
 


### PR DESCRIPTION
[This](https://github.com/axiomhq/hyperloglog/pull/50/commits/bc953295b55658f514c04756857c714fdf143419) commit removed an unused parameter from `variableLengthList.decode(i)`.

When the underlying pull [request](https://github.com/axiomhq/hyperloglog/pull/50) was merged, there was a change needed to `compressed.go` to react to the parameter change.  The testing before this fix shows:

```
go test ./...
# github.com/axiomhq/hyperloglog [github.com/axiomhq/hyperloglog.test]
./compressed.go:113:24: too many arguments in call to v.b.decode
	have (int, uint32)
	want (int)
FAIL	github.com/axiomhq/hyperloglog [build failed]
FAIL
```

After applying this fix:
```
go test ./... -count=1
ok  	github.com/axiomhq/hyperloglog	8.671s
```