### PR TITLE
Optimize slice appending by using slice expansion

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -142,9 +142,7 @@ func (v variableLengthList) AppendBinary(data []byte) ([]byte, error) {
 	)
 
 	// Marshal each element in the list.
-	for i := 0; i < sz; i++ {
-		data = append(data, v[i])
-	}
+	data = append(data, v...)
 
 	return data, nil
 }

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -901,3 +901,38 @@ func Benchmark_Merge(b *testing.B) {
 		}
 	}
 }
+
+func benchmarkMarshalBinary(b *testing.B, size uint8, sparse bool) {
+	sk, _ := NewSketch(size, sparse)
+	for i := 0; i < int(size); i++ {
+		sk.Insert([]byte(fmt.Sprintf("a%d", i)))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = sk.MarshalBinary()
+	}
+}
+
+func Benchmark_MarshalBinary(b *testing.B) {
+	sizes := []int{100, 10000, 1000000}
+	precisions := []uint8{12, 14, 16}
+	sparses := []bool{true, false}
+
+	for _, precision := range precisions {
+		for _, size := range sizes {
+			for _, isSparse := range sparses {
+				name := fmt.Sprintf("Precision_%d/Size_%d/", precision, size)
+				if isSparse {
+					name += "Sparse"
+				} else {
+					name += "NoSparse"
+				}
+				b.Run(name, func(b *testing.B) {
+					benchmarkMarshalBinary(b, precision, isSparse)
+				})
+			}
+		}
+	}
+}

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -902,9 +902,9 @@ func Benchmark_Merge(b *testing.B) {
 	}
 }
 
-func benchmarkMarshalBinary(b *testing.B, size uint8, sparse bool) {
-	sk, _ := NewSketch(size, sparse)
-	for i := 0; i < int(size); i++ {
+func benchmarkMarshalBinary(b *testing.B, precision uint8, size int, sparse bool) {
+	sk, _ := NewSketch(precision, sparse)
+	for i := 0; i < size; i++ {
 		sk.Insert([]byte(fmt.Sprintf("a%d", i)))
 	}
 
@@ -930,7 +930,7 @@ func Benchmark_MarshalBinary(b *testing.B) {
 					name += "NoSparse"
 				}
 				b.Run(name, func(b *testing.B) {
-					benchmarkMarshalBinary(b, precision, isSparse)
+					benchmarkMarshalBinary(b, precision, size, isSparse)
 				})
 			}
 		}


### PR DESCRIPTION
Optimize slice appending by using slice expansion (`append(data, v...)`) instead of a loop.

The benchmark results show a minor improvement in execution time for sparse sketches.

```
goos: darwin
goarch: arm64
pkg: github.com/axiomhq/hyperloglog
cpu: Apple M3
                                                    │   old.txt    │               new.txt                │
                                                    │    sec/op    │    sec/op     vs base                │
_MarshalBinary/Precision_12/Size_100/Sparse-8         350.0n ± 19%   250.0n ± 60%  -28.57% (p=0.014 n=10)
_MarshalBinary/Precision_12/Size_100/NoSparse-8       1.534µ ±  9%   1.575µ ±  6%        ~ (p=0.541 n=10)
_MarshalBinary/Precision_12/Size_10000/Sparse-8       1.554µ ±  6%   1.542µ ±  4%        ~ (p=0.323 n=10)
_MarshalBinary/Precision_12/Size_10000/NoSparse-8     1.525µ ±  3%   1.512µ ± 14%        ~ (p=0.491 n=10)
_MarshalBinary/Precision_12/Size_1000000/Sparse-8     1.533µ ±  3%   1.508µ ±  1%   -1.63% (p=0.029 n=10)
_MarshalBinary/Precision_12/Size_1000000/NoSparse-8   1.525µ ±  2%   1.529µ ± 17%        ~ (p=0.616 n=10)
_MarshalBinary/Precision_14/Size_100/Sparse-8         579.2n ± 15%   654.1n ± 18%        ~ (p=0.122 n=10)
_MarshalBinary/Precision_14/Size_100/NoSparse-8       5.466µ ±  6%   5.484µ ±  4%        ~ (p=0.643 n=10)
_MarshalBinary/Precision_14/Size_10000/Sparse-8       5.904µ ±  8%   5.821µ ±  2%        ~ (p=0.541 n=10)
_MarshalBinary/Precision_14/Size_10000/NoSparse-8     5.980µ ±  4%   5.667µ ±  2%   -5.23% (p=0.002 n=10)
_MarshalBinary/Precision_14/Size_1000000/Sparse-8     5.863µ ±  8%   5.804µ ±  5%        ~ (p=0.362 n=10)
_MarshalBinary/Precision_14/Size_1000000/NoSparse-8   5.854µ ±  4%   5.792µ ±  7%        ~ (p=0.927 n=10)
_MarshalBinary/Precision_16/Size_100/Sparse-8         608.3n ± 58%   604.1n ± 23%        ~ (p=0.698 n=10)
_MarshalBinary/Precision_16/Size_100/NoSparse-8       21.12µ ±  3%   21.33µ ±  4%        ~ (p=0.529 n=10)
_MarshalBinary/Precision_16/Size_10000/Sparse-8       7.900µ ±  3%   1.296µ ± 65%  -83.60% (p=0.000 n=10)
_MarshalBinary/Precision_16/Size_10000/NoSparse-8     20.70µ ±  1%   20.37µ ±  2%        ~ (p=0.072 n=10)
_MarshalBinary/Precision_16/Size_1000000/Sparse-8     20.66µ ±  3%   20.38µ ±  4%   -1.33% (p=0.045 n=10)
_MarshalBinary/Precision_16/Size_1000000/NoSparse-8   20.75µ ±  2%   20.34µ ±  1%   -1.99% (p=0.015 n=10)
geomean                                               3.599µ         3.192µ        -11.30%
```