### PR TITLE
deps: update github.com/kamstrup/intmap to v0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33
-	github.com/kamstrup/intmap v0.5.1
+	github.com/kamstrup/intmap v0.5.2
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 h1:ucRHb6/lvW/+mTEIGbvhcYU3S8+uSNkuMjx/qZFfhtM=
 github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
-github.com/kamstrup/intmap v0.5.1 h1:ENGAowczZA+PJPYYlreoqJvWgQVtAmX1l899WfYFVK0=
-github.com/kamstrup/intmap v0.5.1/go.mod h1:gWUVWHKzWj8xpJVFf5GC0O26bWmv3GqdnIX/LMT6Aq4=
+github.com/kamstrup/intmap v0.5.2 h1:qnwBm1mh4XAnW9W9Ue9tZtTff8pS6+s6iKF6JRIV2Dk=
+github.com/kamstrup/intmap v0.5.2/go.mod h1:gWUVWHKzWj8xpJVFf5GC0O26bWmv3GqdnIX/LMT6Aq4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=


### PR DESCRIPTION
The [v0.5.2](https://github.com/kamstrup/intmap/releases/tag/v0.5.2) release of kamstrup/intmap reduces the memory usage of Sets by half as well as a few other small performance gains.

```
goos: darwin
goarch: arm64
pkg: github.com/axiomhq/hyperloglog
cpu: Apple M4 Pro
                                                     │ base.10.txt  │              new.10.txt              │
                                                     │    sec/op    │    sec/op     vs base                │
_HLL_Marshal/precision16_sparse/MarshalBinary-14       1.256µ ±  2%   1.155µ ±  7%   -8.00% (p=0.001 n=10)
_HLL_Marshal/precision16_sparse/AppendBinary-14        926.4n ±  1%   885.4n ±  0%   -4.43% (p=0.000 n=10)
_HLL_Marshal/precision16_dense/MarshalBinary-14        20.63µ ±  1%   19.72µ ±  1%   -4.39% (p=0.000 n=10)
_HLL_Marshal/precision16_dense/AppendBinary-14         17.56µ ±  0%   17.54µ ±  1%        ~ (p=0.645 n=10)
_Size_New_Sparse-14                                    45.29n ±  2%   42.41n ±  1%   -6.35% (p=0.000 n=10)
_Add_100-14                                            767.0n ±  2%   751.4n ±  2%   -2.02% (p=0.005 n=10)
_Add_1000-14                                           65.63µ ±  1%   61.96µ ±  4%   -5.59% (p=0.000 n=10)
_Add_10000-14                                          1.393m ±  1%   1.362m ±  2%   -2.20% (p=0.001 n=10)
_Add_100000-14                                         432.5µ ±  1%   431.4µ ±  1%        ~ (p=0.315 n=10)
_Add_1000000-14                                        4.339m ±  1%   4.273m ±  1%   -1.52% (p=0.002 n=10)
_Add_10000000-14                                       43.01m ±  1%   42.45m ±  1%   -1.31% (p=0.029 n=10)
_Add_100000000-14                                      433.3m ±  2%   428.0m ±  2%   -1.21% (p=0.019 n=10)
Zipf/s1.1/b3-14                                        8.228n ± 17%   8.067n ±  1%   -1.96% (p=0.001 n=10)
Zipf/s1.1/b10-14                                       48.52n ±  2%   45.95n ±  1%   -5.31% (p=0.000 n=10)
Zipf/s1.1/b64-14                                       5.512n ±  0%   5.202n ±  4%   -5.61% (p=0.000 n=10)
Zipf/s1.5/b3-14                                        7.980n ±  2%   7.110n ± 12%  -10.90% (p=0.003 n=10)
Zipf/s1.5/b10-14                                       19.07n ±  2%   18.64n ±  1%   -2.25% (p=0.000 n=10)
Zipf/s1.5/b64-14                                       5.607n ±  1%   5.564n ±  1%   -0.78% (p=0.050 n=10)
Zipf/s2/b3-14                                          7.857n ±  1%   7.813n ±  1%        ~ (p=0.190 n=10)
Zipf/s2/b10-14                                         9.152n ±  1%   9.019n ±  0%   -1.46% (p=0.000 n=10)
Zipf/s2/b64-14                                         7.481n ±  3%   7.831n ±  3%   +4.68% (p=0.002 n=10)
Zipf/s5/b3-14                                          7.439n ±  1%   7.707n ±  1%   +3.60% (p=0.000 n=10)
Zipf/s5/b10-14                                         7.495n ±  0%   7.772n ±  1%   +3.70% (p=0.000 n=10)
Zipf/s5/b64-14                                         7.527n ±  0%   7.759n ±  1%   +3.08% (p=0.000 n=10)
_Merge/size1=100/size2=100-14                          5.903µ ±  1%   5.447µ ±  3%   -7.72% (p=0.000 n=10)
_Merge/size1=100/size2=10000-14                        34.11µ ± 12%   35.79µ ±  3%        ~ (p=0.128 n=10)
_Merge/size1=100/size2=1000000-14                      10.49µ ±  2%   10.51µ ±  1%        ~ (p=0.986 n=10)
_Merge/size1=10000/size2=100-14                        31.99µ ±  9%   31.78µ ±  8%        ~ (p=0.853 n=10)
_Merge/size1=10000/size2=10000-14                      70.67µ ±  2%   71.69µ ±  3%        ~ (p=0.093 n=10)
_Merge/size1=10000/size2=1000000-14                    41.22µ ±  4%   42.42µ ±  3%   +2.93% (p=0.035 n=10)
_Merge/size1=1000000/size2=100-14                      7.467µ ±  1%   7.771µ ±  2%   +4.08% (p=0.000 n=10)
_Merge/size1=1000000/size2=10000-14                    13.22µ ±  6%   14.17µ ±  2%   +7.22% (p=0.001 n=10)
_Merge/size1=1000000/size2=1000000-14                  34.36µ ±  9%   35.14µ ±  7%        ~ (p=0.280 n=10)
geomean                                                2.320µ         2.304µ         -0.68%

                                                     │  base.10.txt   │               new.10.txt               │
                                                     │      B/op      │     B/op      vs base                  │
_Size_New_Sparse-14                                      160.0 ± 0%       152.0 ± 0%   -5.00% (p=0.000 n=10)
_Add_100-14                                              0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
_Add_1000-14                                           37.63Ki ± 0%     25.45Ki ± 0%  -32.37% (p=0.000 n=10)
_Add_10000-14                                          650.3Ki ± 0%     528.5Ki ± 0%  -18.73% (p=0.000 n=10)
_Add_100000-14                                         2.512Ki ± 3%     2.151Ki ± 2%  -14.36% (p=0.000 n=10)
_Add_1000000-14                                        22.34Ki ± 1%     19.04Ki ± 1%  -14.78% (p=0.000 n=10)
_Add_10000000-14                                       250.4Ki ± 8%     215.8Ki ± 8%  -13.83% (p=0.000 n=10)
_Add_100000000-14                                      1.467Mi ± 0%     1.264Mi ± 0%  -13.83% (p=0.000 n=10)
_Merge/size1=100/size2=100-14                          9.969Ki ± 0%     5.969Ki ± 0%  -40.13% (p=0.000 n=10)
_Merge/size1=100/size2=10000-14                        21.03Ki ± 0%     19.03Ki ± 0%   -9.51% (p=0.000 n=10)
_Merge/size1=100/size2=1000000-14                      21.03Ki ± 0%     19.03Ki ± 0%   -9.51% (p=0.000 n=10)
_Merge/size1=10000/size2=100-14                        16.16Ki ± 0%     16.15Ki ± 0%   -0.05% (p=0.000 n=10)
_Merge/size1=10000/size2=10000-14                      16.16Ki ± 0%     16.15Ki ± 0%   -0.05% (p=0.000 n=10)
_Merge/size1=10000/size2=1000000-14                    16.16Ki ± 0%     16.15Ki ± 0%   -0.05% (p=0.000 n=10)
_Merge/size1=1000000/size2=100-14                      16.16Ki ± 0%     16.15Ki ± 0%   -0.05% (p=0.000 n=10)
_Merge/size1=1000000/size2=10000-14                    16.16Ki ± 0%     16.15Ki ± 0%   -0.05% (p=0.000 n=10)
_Merge/size1=1000000/size2=1000000-14                  16.16Ki ± 0%     16.15Ki ± 0%   -0.05% (p=0.000 n=10)
geomean                                                             ²                  -5.50%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```