### PR TITLE
allow compiler to inline hash function

### DIFF
--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -24,13 +24,6 @@ func estimateError(got, exp uint64) float64 {
 	return float64(delta) / float64(exp)
 }
 
-func nopHash(buf []byte) uint64 {
-	if len(buf) != 8 {
-		panic(fmt.Sprintf("unexpected size buffer: %d", len(buf)))
-	}
-	return binary.BigEndian.Uint64(buf)
-}
-
 func TestHLL_CardinalityHashed(t *testing.T) {
 	hlltc, err := NewSketch(14, true)
 	require.NoError(t, err)
@@ -64,64 +57,52 @@ func toByte(v uint64) []byte {
 }
 
 func TestHLL_Add_NoSparse(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := New16NoSparse()
 
-	sk.Insert(toByte(0x00010fffffffffff))
+	sk.InsertHash(0x00010fffffffffff)
 	n := sk.regs[1]
 	require.EqualValues(t, 5, n)
 
-	sk.Insert(toByte(0x0002ffffffffffff))
+	sk.InsertHash(0x0002ffffffffffff)
 	n = sk.regs[2]
 	require.EqualValues(t, 1, n)
 
-	sk.Insert(toByte(0x0003000000000000))
+	sk.InsertHash(0x0003000000000000)
 	n = sk.regs[3]
 	require.EqualValues(t, 49, n)
 
-	sk.Insert(toByte(0x0003000000000001))
+	sk.InsertHash(0x0003000000000001)
 	n = sk.regs[3]
 	require.EqualValues(t, 49, n)
 
-	sk.Insert(toByte(0xff03700000000000))
+	sk.InsertHash(0xff03700000000000)
 	n = sk.regs[0xff03]
 	require.EqualValues(t, 2, n)
 
-	sk.Insert(toByte(0xff03080000000000))
+	sk.InsertHash(0xff03080000000000)
 	n = sk.regs[0xff03]
 	require.EqualValues(t, 5, n)
 }
 
 func TestHLL_Precision_NoSparse(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk, _ := NewSketch(4, false)
 
-	sk.Insert(toByte(0x1fffffffffffffff))
+	sk.InsertHash(0x1fffffffffffffff)
 	n := sk.regs[1]
 	require.EqualValues(t, 1, n)
 
-	sk.Insert(toByte(0xffffffffffffffff))
+	sk.InsertHash(0xffffffffffffffff)
 	n = sk.regs[0xf]
 	require.EqualValues(t, 1, n)
 
-	sk.Insert(toByte(0x00ffffffffffffff))
+	sk.InsertHash(0x00ffffffffffffff)
 	n = sk.regs[0]
 	require.EqualValues(t, 5, n)
 }
 
 func TestHLL_toNormal(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := NewTestSketch(16)
-	sk.Insert(toByte(0x00010fffffffffff))
+	sk.InsertHash(0x00010fffffffffff)
 	sk.toNormal()
 	c := sk.Estimate()
 	require.EqualValues(t, 1, c)
@@ -129,12 +110,12 @@ func TestHLL_toNormal(t *testing.T) {
 	require.False(t, sk.sparse(), "toNormal should convert to normal")
 
 	sk = NewTestSketch(16)
-	sk.Insert(toByte(0x00010fffffffffff))
-	sk.Insert(toByte(0x0002ffffffffffff))
-	sk.Insert(toByte(0x0003000000000000))
-	sk.Insert(toByte(0x0003000000000001))
-	sk.Insert(toByte(0xff03700000000000))
-	sk.Insert(toByte(0xff03080000000000))
+	sk.InsertHash(0x00010fffffffffff)
+	sk.InsertHash(0x0002ffffffffffff)
+	sk.InsertHash(0x0003000000000000)
+	sk.InsertHash(0x0003000000000001)
+	sk.InsertHash(0xff03700000000000)
+	sk.InsertHash(0xff03080000000000)
 	sk.mergeSparse()
 	sk.toNormal()
 
@@ -149,10 +130,6 @@ func TestHLL_toNormal(t *testing.T) {
 }
 
 func TestHLL_Cardinality(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := NewTestSketch(16)
 
 	n := sk.Estimate()
@@ -180,10 +157,6 @@ func TestHLL_Cardinality(t *testing.T) {
 }
 
 func TestHLL_Merge_Error(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := NewTestSketch(16)
 	sk2 := NewTestSketch(10)
 
@@ -192,10 +165,6 @@ func TestHLL_Merge_Error(t *testing.T) {
 }
 
 func TestHLL_Merge_Sparse(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := NewTestSketch(16)
 	sk.Insert(toByte(0x00010fffffffffff))
 	sk.Insert(toByte(0x00020fffffffffff))
@@ -279,10 +248,6 @@ func TestHLL_Merge_Complex(t *testing.T) {
 }
 
 func TestHLL_EncodeDecode(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := NewTestSketch(8)
 	i, r := decodeHash(encodeHash(0xffffff8000000000, sk.p, pp), sk.p, pp)
 	require.EqualValues(t, 0xff, i)
@@ -547,10 +512,6 @@ func TestHLL_Clone(t *testing.T) {
 }
 
 func TestHLL_Add_Hash(t *testing.T) {
-	hash = nopHash
-	defer func() {
-		hash = hashFunc
-	}()
 	sk := NewTestSketch(16)
 
 	n := sk.Estimate()

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -629,6 +629,17 @@ func Benchmark_Size_New_Sparse(b *testing.B) {
 	_ = sk
 }
 
+func Benchmark_Insert(b *testing.B) {
+	sk := New16NoSparse()
+	value := []byte("benchmark")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sk.Insert(value)
+	}
+}
+
 func Benchmark_Add_100(b *testing.B) {
 	sk, _ := NewSketch(16, true)
 	benchmarkAdd(b, sk, 100)

--- a/utils.go
+++ b/utils.go
@@ -7,8 +7,6 @@ import (
 	metro "github.com/dgryski/go-metro"
 )
 
-var hash = hashFunc
-
 func alpha(m float64) float64 {
 	switch m {
 	case 16:
@@ -41,6 +39,6 @@ func bextr32(v uint32, start, length uint8) uint32 {
 	return (v >> start) & ((1 << length) - 1)
 }
 
-func hashFunc(e []byte) uint64 {
+func hash(e []byte) uint64 {
 	return metro.Hash64(e, 1337)
 }


### PR DESCRIPTION
#### allow compiler to inline hash function

The package-level variable `hash` function has been turned into a named
function. This allows the Go compiler to inline the function, improving
performance.

With profile-guided optimization (PGO), the Go compiler is able to
inline the variable function without this change. But I'm skeptical that
PGO is widely used, so I think this is still valuable.

Some tests using `Sketch.Insert` had to be re-written to use
`Sketch.InsertHash`. However, `Sketch.Insert` is still tested, so I
don't believe this will be too controversial.

Before/after results of `Benchmark_Add_*`:

```
name               old time/op    new time/op    delta
_Add_100-16           879ns ± 5%     793ns ±14%   -9.81%  (p=0.004 n=10+10)
_Add_1000-16         81.5µs ± 6%    77.1µs ± 4%   -5.30%  (p=0.009 n=10+10)
_Add_10000-16        1.66ms ± 1%    1.67ms ± 1%     ~     (p=0.356 n=10+9)
_Add_100000-16       1.06ms ± 0%    0.99ms ± 0%   -6.58%  (p=0.000 n=9+9)
_Add_1000000-16      7.95ms ± 1%    7.09ms ± 1%  -10.86%  (p=0.000 n=8+10)
_Add_10000000-16     71.4ms ± 1%    62.4ms ± 0%  -12.58%  (p=0.000 n=10+10)
_Add_100000000-16     715ms ± 0%     615ms ± 0%  -13.98%  (p=0.000 n=7+9)

name               old alloc/op   new alloc/op   delta
_Add_100-16           1.00B ± 0%     1.00B ± 0%     ~     (all equal)
_Add_1000-16         26.1kB ± 0%    26.1kB ± 0%     ~     (all equal)
_Add_10000-16         541kB ± 0%     541kB ± 0%     ~     (p=0.620 n=9+9)
_Add_100000-16       10.6kB ± 0%    10.6kB ± 0%     ~     (all equal)
_Add_1000000-16      26.5kB ± 0%    26.5kB ± 0%     ~     (all equal)
_Add_10000000-16     53.0kB ± 0%    53.0kB ± 0%     ~     (all equal)
_Add_100000000-16     133kB ± 0%     133kB ± 0%     ~     (all equal)

name               old allocs/op  new allocs/op  delta
_Add_100-16            0.00           0.00          ~     (all equal)
_Add_1000-16           21.0 ± 0%      21.0 ± 0%     ~     (all equal)
_Add_10000-16           213 ± 0%       213 ± 0%     ~     (all equal)
_Add_100000-16         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
_Add_1000000-16        7.00 ± 0%      7.00 ± 0%     ~     (all equal)
_Add_10000000-16       14.0 ± 0%      14.0 ± 0%     ~     (all equal)
_Add_100000000-16      36.0 ± 0%      36.0 ± 0%     ~     (all equal)
```
