### PR TITLE
Harden UnmarshalBinary validation

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -2,6 +2,7 @@ package hyperloglog
 
 import (
 	"encoding/binary"
+	"fmt"
 	"slices"
 )
 
@@ -76,26 +77,63 @@ func (v *compressedList) AppendBinary(data []byte) ([]byte, error) {
 	return v.b.AppendBinary(data)
 }
 
-func (v *compressedList) UnmarshalBinary(data []byte) error {
+// unmarshal requires p to have passed checkPrecision, and data to be exactly
+// the compressed list; trailing bytes are rejected.
+func (v *compressedList) unmarshal(data []byte, p uint8) error {
 	if len(data) < 12 {
-		return ErrorTooShort
+		return fmt.Errorf("hyperloglog: compressed list header needs 12 bytes, have %d: %w", len(data), ErrorTooShort)
 	}
 
-	// Set the count.
-	v.count, data = binary.BigEndian.Uint32(data[:4]), data[4:]
+	// Read the count.
+	count, data := binary.BigEndian.Uint32(data[:4]), data[4:]
 
-	// Set the last value.
-	v.last, data = binary.BigEndian.Uint32(data[:4]), data[4:]
+	// Read the last value.
+	last, data := binary.BigEndian.Uint32(data[:4]), data[4:]
 
-	// Set the list.
+	// Read the size of the list.
 	sz, data := binary.BigEndian.Uint32(data[:4]), data[4:]
-	v.b = make([]uint8, sz)
-	if uint32(len(data)) < sz {
-		return ErrorTooShort
+	if err := exactLen("compressed list stream", uint64(len(data)), uint64(sz)); err != nil {
+		return err
 	}
-	for i := uint32(0); i < sz; i++ {
-		v.b[i] = data[i]
+
+	b := make(variableLengthList, sz)
+	copy(b, data[:sz])
+
+	// Walk the stream once, decoding each varint exactly once, so that count
+	// and last cannot describe something the payload does not contain.
+	var entries uint32
+	var running uint32
+	for i := 0; i < int(sz); {
+		off := i
+		x, end, ok := b.decode(off)
+		if !ok {
+			return fmt.Errorf("hyperloglog: compressed list varint at compressed-list offset %d is malformed: %w", off, ErrorInvalidData)
+		}
+		i = end
+		// Every delta after the first strictly increases the running key, so
+		// the decoded keys strictly increase, the sum cannot wrap, and count
+		// cannot be inflated by duplicates.
+		next := running + x
+		if entries > 0 && next <= running {
+			return fmt.Errorf("hyperloglog: compressed list delta %d at compressed-list offset %d does not increase the key past %d: %w", entries, off, running, ErrorInvalidData)
+		}
+		running = next
+		if err := checkSparseKey(running, p); err != nil {
+			return fmt.Errorf("hyperloglog: compressed-list offset %d: %w", off, err)
+		}
+		entries++
 	}
+	if count != entries {
+		return fmt.Errorf("hyperloglog: compressed list count %d, decoded %d entries: %w", count, entries, ErrorInvalidData)
+	}
+	if count >= mp {
+		return fmt.Errorf("hyperloglog: compressed list count %d >= %d: %w", count, mp, ErrorInvalidData)
+	}
+	if last != running {
+		return fmt.Errorf("hyperloglog: compressed list last %d, decoded %d: %w", last, running, ErrorInvalidData)
+	}
+
+	v.count, v.last, v.b = count, last, b
 	return nil
 }
 
@@ -109,8 +147,9 @@ func (v *compressedList) Len() int {
 	return len(v.b)
 }
 
+// decode ignores b.decode's ok: streams reach here only after unmarshal validated them or Append built them, and a malformed stream would still return next == len(v), terminating Iter.
 func (v *compressedList) decode(i int, last uint32) (uint32, int) {
-	n, i := v.b.decode(i)
+	n, i, _ := v.b.decode(i)
 	return n + last, i
 }
 
@@ -157,14 +196,24 @@ func (v *variableLengthList) clear() {
 	*v = (*v)[:0]
 }
 
-func (v variableLengthList) decode(i int) (uint32, int) {
-	var x uint32
+// decode reads the varint at offset i and returns its value and the offset of
+// the next one. ok is false when the varint runs past the end of v, spans more
+// than 5 bytes, does not fit in 32 bits, or is not minimally encoded; next is
+// then len(v), so a loop driven by next terminates on a malformed stream.
+func (v variableLengthList) decode(i int) (x uint32, next int, ok bool) {
 	j := i
-	for ; v[j]&0x80 != 0; j++ {
+	for ; j < len(v) && v[j]&0x80 != 0; j++ {
 		x |= uint32(v[j]&0x7f) << (uint(j-i) * 7)
 	}
+	if j >= len(v) {
+		return x, len(v), false
+	}
 	x |= uint32(v[j]) << (uint(j-i) * 7)
-	return x, j + 1
+	n := j - i + 1
+	if n > 5 || (n == 5 && v[j] > 0x0f) || (n > 1 && v[j] == 0) {
+		return x, len(v), false
+	}
+	return x, j + 1, true
 }
 
 func (v variableLengthList) Append(x uint32) variableLengthList {

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -43,9 +43,33 @@ func newSketchNoError(precision uint8, sparse bool) *Sketch {
 	return sk
 }
 
+func checkPrecision(p uint8) error {
+	if p < 4 || p > 18 {
+		return ErrorInvalidPrecision
+	}
+	return nil
+}
+
+func exactLen(what string, have, want uint64) error {
+	switch {
+	case have == want:
+		return nil
+	case have < want:
+		return fmt.Errorf("hyperloglog: %s need %d bytes, have %d: %w", what, want, have, ErrorTooShort)
+	default:
+		return fmt.Errorf("hyperloglog: %s need %d bytes, %d bytes follow them: %w", what, want, have-want, ErrorInvalidData)
+	}
+}
+
+func maxRho(p uint8) uint8 { return 64 - p + 1 }
+
+// NewSketch returns a HyperLogLog Sketch with 2^precision registers. The
+// precision has to be >= 4 and <= 18, otherwise ErrorInvalidPrecision is
+// returned. When sparse is true the Sketch starts out in the sparse
+// representation.
 func NewSketch(precision uint8, sparse bool) (*Sketch, error) {
-	if precision < 4 || precision > 18 {
-		return nil, fmt.Errorf("p has to be >= 4 and <= 18")
+	if err := checkPrecision(precision); err != nil {
+		return nil, err
 	}
 	m := uint32(1) << precision
 	s := &Sketch{
@@ -223,7 +247,22 @@ func (sk *Sketch) MarshalBinary() (data []byte, err error) {
 }
 
 // AppendBinary implements the encoding.BinaryAppender interface.
+// UnmarshalBinary requires the encoding to be the entire buffer it is handed
+// and rejects trailing bytes with ErrorInvalidData. A caller appending a Sketch
+// into a larger buffer must frame the record itself; the number of bytes
+// appended is len(result) - len(data).
+//
+// The encoding is not canonical: two sketches holding the same values may
+// encode to different bytes, depending on insertion order and on whether
+// Estimate has compacted the sparse representation. An encoding must not be
+// hashed, deduplicated, or compared for equality to decide whether two
+// sketches hold the same values.
 func (sk *Sketch) AppendBinary(data []byte) ([]byte, error) {
+	// Refuse to write a header no UnmarshalBinary would accept, and leave the
+	// caller's buffer untouched when we do.
+	if err := checkPrecision(sk.p); err != nil {
+		return data, fmt.Errorf("hyperloglog: precision %d: %w", sk.p, err)
+	}
 	data = slices.Grow(data, 8+len(sk.regs))
 	// Marshal a version marker.
 	data = append(data, version)
@@ -266,67 +305,171 @@ func (sk *Sketch) AppendBinary(data []byte) ([]byte, error) {
 	return data, nil
 }
 
-// ErrorTooShort is an error that UnmarshalBinary try to parse too short
-// binary.
+// ErrorTooShort is returned, wrapped, when a buffer ends before the format
+// requires. UnmarshalBinary used to return it unwrapped, so err ==
+// ErrorTooShort is now always false and callers have to use errors.Is.
 var ErrorTooShort = errors.New("too short binary")
 
+// ErrorInvalidVersion is returned by UnmarshalBinary when the version byte is
+// neither 1 nor 2.
+var ErrorInvalidVersion = errors.New("unknown serialization version")
+
+// ErrorInvalidPrecision is returned unwrapped by NewSketch, and wrapped by
+// UnmarshalBinary, when the precision is outside the supported range.
+var ErrorInvalidPrecision = errors.New("p has to be >= 4 and <= 18")
+
+// ErrorInvalidData is returned by UnmarshalBinary when the binary is long
+// enough but describes a state that cannot be decoded.
+var ErrorInvalidData = errors.New("invalid binary data")
+
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+//
+// The binary format starts with a 4 byte header:
+//
+//	byte 0: version. 2 is written; 1 and 2 are accepted, anything else
+//	        returns ErrorInvalidVersion.
+//	byte 1: precision p, which must be in [4, 18], otherwise
+//	        ErrorInvalidPrecision is returned.
+//	byte 2: b, the register bias of the version 1 dense payload. It is
+//	        ignored for sparse payloads of either version. Version 2 writes
+//	        0 and requires 0.
+//	byte 3: 1 if the payload is sparse, 0 if it is dense.
+//
+// The sparse payload is identical for version 1 and 2: a uint32 big endian
+// count N of tmp set keys, followed by N uint32 big endian keys, followed by
+// the compressed list: a uint32 big endian count, a uint32 big endian last
+// value, a uint32 big endian size sz, and sz bytes of a delta varint stream
+// whose final byte must have its high bit clear. The tmp set keys may appear in
+// any order.
+//
+// The version 2 dense payload is a uint32 big endian register count, which
+// must equal m = 1<<p, followed by m register bytes. In the version 1 dense
+// payload bytes 4:8 are ignored and bytes 8: hold m/2 bytes of two 4 bit
+// registers each, both biased by b.
+//
+// Byte 2 must be 0 when the version is 2, and byte 3 must be 0 or 1; any other
+// value returns ErrorInvalidData. The compressed list's count must equal the
+// number of varints in its stream and must be less than 2^25, and its last
+// value must equal the sum of the deltas, otherwise ErrorInvalidData is
+// returned. Each delta varint must be at most 5 bytes long, minimally encoded,
+// and must fit in 32 bits. The running sum of the deltas must strictly
+// increase after the first delta and must not wrap; a first delta of 0 is
+// legal. A violation of either rule returns ErrorInvalidData. Every decoded
+// sparse key and every dense register must decode to a value no greater than
+// 64-p+1, otherwise ErrorInvalidData is returned.
+//
+// The payload must end exactly where its declared lengths say it does: bytes
+// following the sparse compressed list, the version 2 registers, or the
+// version 1 packed registers return ErrorInvalidData.
+//
+// Version, precision and every length prefix are validated before the receiver
+// is mutated, so the receiver is never left with registers or a sparse list
+// shorter than the layout implies. If an error is returned sk is left
+// unchanged. Every error returned by UnmarshalBinary wraps one of the
+// exported sentinels above and has to be matched with errors.Is rather than
+// with ==.
 func (sk *Sketch) UnmarshalBinary(data []byte) error {
 	if len(data) < 8 {
-		return ErrorTooShort
+		return fmt.Errorf("hyperloglog: header needs 8 bytes, have %d: %w", len(data), ErrorTooShort)
 	}
 
 	// Unmarshal version. We may need this in the future if we make
 	// non-compatible changes.
 	v := data[0]
+	if v != 1 && v != 2 {
+		return fmt.Errorf("hyperloglog: version %d: %w", v, ErrorInvalidVersion)
+	}
 
 	// Unmarshal p.
 	p := data[1]
 
-	// Unmarshal b.
-	b := data[2]
-
 	// Determine if we need a sparse Sketch
-	sparse := data[3] == byte(1)
+	if data[3] > 1 {
+		return fmt.Errorf("hyperloglog: header byte 3 = %d: %w", data[3], ErrorInvalidData)
+	}
+	sparse := data[3] == 1
 
-	// Make a newSketch Sketch if the precision doesn't match or if the Sketch was used
-	if sk.p != p || sk.regs != nil || sk.tmpSet.Len() > 0 || (sk.sparseList != nil && sk.sparseList.Len() > 0) {
-		newh, err := NewSketch(p, sparse)
-		if err != nil {
-			return err
-		}
-		*sk = *newh
+	// Unmarshal b. Only the version 1 dense encoding has a register bias.
+	b := data[2]
+	if v == 2 && b != 0 {
+		return fmt.Errorf("hyperloglog: header byte 2 = %d for version 2: %w", b, ErrorInvalidData)
 	}
 
-	// h is now initialised with the correct p. We just need to fill the
-	// rest of the details out.
-	if sparse {
+	// Validate the precision before anything is sized from it, so that a
+	// header declaring a large p cannot allocate registers the payload does
+	// not have. The scratch Sketch below is only built once the declared
+	// lengths check out, and the receiver is only replaced once the whole
+	// payload has parsed.
+	if err := checkPrecision(p); err != nil {
+		return fmt.Errorf("hyperloglog: precision %d: %w", p, err)
+	}
+	m := uint32(1) << p
+
+	// The parsed sketch is only committed to the receiver at the single exit
+	// below, after the whole payload has been validated.
+	var tmp *Sketch
+
+	switch {
+	case sparse:
 		// Using the sparse Sketch.
 
 		// Unmarshal the tmp_set.
 		tssz := binary.BigEndian.Uint32(data[4:8])
-		sk.tmpSet = makeSet(int(tssz))
 
 		// We need to unmarshal tssz values in total, and each value requires us
 		// to read 4 bytes.
-		tsLastByte := int((tssz * 4) + 8)
+		need := 8 + 4*uint64(tssz)
+		if need > uint64(len(data)) {
+			return fmt.Errorf("hyperloglog: tmp set of %d keys needs %d bytes, have %d: %w", tssz, need, len(data), ErrorTooShort)
+		}
+		tmp = newSketchNoError(p, true)
+		tmp.tmpSet = makeSet(int(tssz))
+
+		tsLastByte := int(need)
 		for i := 8; i < tsLastByte; i += 4 {
 			k := binary.BigEndian.Uint32(data[i : i+4])
-			sk.tmpSet.add(k)
+			if err := checkSparseKey(k, p); err != nil {
+				return fmt.Errorf("hyperloglog: tmp set key at offset %d: %w", i, err)
+			}
+			tmp.tmpSet.add(k)
 		}
 
 		// Unmarshal the sparse Sketch.
-		return sk.sparseList.UnmarshalBinary(data[tsLastByte:])
+		if err := tmp.sparseList.unmarshal(data[tsLastByte:], p); err != nil {
+			return fmt.Errorf("hyperloglog: compressed list at offset %d: %w", tsLastByte, err)
+		}
+
+	case v == 1:
+		// Using the version 1 dense Sketch, where two 4 bit registers are
+		// packed into each byte.
+		payload := data[8:]
+		nb := int(m) / 2
+		if err := exactLen("v1 dense registers at offset 8", uint64(len(payload)), uint64(nb)); err != nil {
+			return err
+		}
+		tmp = newSketchNoError(p, false)
+		if err := tmp.unmarshalBinaryV1(payload, b); err != nil {
+			return err
+		}
+
+	default:
+		// Using the version 2 dense Sketch.
+		payload := data[8:]
+		sz := binary.BigEndian.Uint32(data[4:8])
+		if uint64(sz) != uint64(m) {
+			return fmt.Errorf("hyperloglog: dense register count %d, want m = %d: %w", sz, m, ErrorInvalidData)
+		}
+		if err := exactLen("dense registers at offset 8", uint64(len(payload)), uint64(sz)); err != nil {
+			return err
+		}
+		tmp = newSketchNoError(p, false)
+		if err := tmp.unmarshalBinaryV2(payload); err != nil {
+			return err
+		}
 	}
 
-	// Using the dense Sketch.
-	sk.sparseList = nil
-	sk.tmpSet = nilSet
-
-	if v == 1 {
-		return sk.unmarshalBinaryV1(data[8:], b)
-	}
-	return sk.unmarshalBinaryV2(data)
+	*sk = *tmp
+	return nil
 }
 
 func sumAndZeros(regs []uint8) (res, ez float64) {
@@ -339,17 +482,36 @@ func sumAndZeros(regs []uint8) (res, ez float64) {
 	return res, ez
 }
 
+// unmarshalBinaryV1 requires len(sk.regs) == int(sk.m) and
+// len(data) == int(sk.m)/2.
 func (sk *Sketch) unmarshalBinaryV1(data []byte, b uint8) error {
-	sk.regs = make([]uint8, len(data)*2)
+	maxRho := maxRho(sk.p)
 	for i, v := range data {
-		sk.regs[i*2] = uint8((v >> 4)) + b
-		sk.regs[i*2+1] = uint8((v<<4)>>4) + b
+		// Widen before adding the bias so that it cannot wrap.
+		hi := uint16(v>>4) + uint16(b)
+		lo := uint16(v&0x0f) + uint16(b)
+		if hi > uint16(maxRho) {
+			return fmt.Errorf("hyperloglog: v1 register %d = %d at offset %d, max %d: %w", i*2, hi, 8+i, maxRho, ErrorInvalidData)
+		}
+		if lo > uint16(maxRho) {
+			return fmt.Errorf("hyperloglog: v1 register %d = %d at offset %d, max %d: %w", i*2+1, lo, 8+i, maxRho, ErrorInvalidData)
+		}
+		sk.regs[i*2] = uint8(hi)
+		sk.regs[i*2+1] = uint8(lo)
 	}
 	return nil
 }
 
+// unmarshalBinaryV2 requires len(sk.regs) == int(sk.m) and
+// len(data) == int(sk.m).
 func (sk *Sketch) unmarshalBinaryV2(data []byte) error {
-	sk.regs = data[8:]
+	maxRho := maxRho(sk.p)
+	copy(sk.regs, data)
+	for i, r := range sk.regs {
+		if r > maxRho {
+			return fmt.Errorf("hyperloglog: register %d = %d, max %d: %w", i, r, maxRho, ErrorInvalidData)
+		}
+	}
 	return nil
 }
 

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -3,6 +3,7 @@ package hyperloglog
 import (
 	crand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -289,7 +290,7 @@ func TestHLL_Marshal_Unmarshal_Sparse(t *testing.T) {
 
 	// Add a bunch of values to the sparse representation.
 	for i := 0; i < 10; i++ {
-		sk.sparseList.Append(uint32(rand.Int()))
+		sk.sparseList.Append(uint32(i+1) << 1)
 	}
 
 	data, err := sk.MarshalBinary()
@@ -319,7 +320,7 @@ func TestHLL_Marshal_Unmarshal_Dense(t *testing.T) {
 
 	// Add a bunch of values to the dense representation.
 	for i := uint32(0); i < 10; i++ {
-		sk.regs[i] = uint8(rand.Int())
+		sk.regs[i] = uint8(rand.Intn(int(64 - sk.p + 2)))
 	}
 
 	data, err := sk.MarshalBinary()
@@ -392,12 +393,12 @@ func TestHLL_Marshal_Unmarshal_Count(t *testing.T) {
 	require.LessOrEqual(t, math.Abs(float64(int(gotC)-len(count))), float64(epsilon), "error was %v for estimation %d and true cardinality %d", math.Abs(float64(int(gotC)-len(count))), gotC, len(count))
 }
 
-// Tests that a sketch will be used in Unmarshal if it is unused
-func TestHLL_Marshal_Unmarshal_Reuse(t *testing.T) {
+// Tests that Unmarshal always replaces the receiver, used or not.
+func TestHLL_Unmarshal_ReplacesReceiver(t *testing.T) {
 	sk, _ := NewSketch(4, true)
 	// Add a bunch of values to the sparse representation.
 	for i := 0; i < 10; i++ {
-		sk.sparseList.Append(uint32(rand.Int()))
+		sk.sparseList.Append(uint32(i+1) << 1)
 	}
 	data, err := sk.MarshalBinary()
 	require.NoError(t, err)
@@ -407,32 +408,383 @@ func TestHLL_Marshal_Unmarshal_Reuse(t *testing.T) {
 	res.m = 1
 	require.NoError(t, res.UnmarshalBinary(data))
 
-	// Compare the "m" to make sure it's the same
-	require.EqualValues(t, 1, res.m, "UnmarshalBinary created a newSketch Sketch")
+	// The tampered receiver is discarded, so "m" matches the encoded precision
+	require.EqualValues(t, uint32(1)<<res.p, res.m, "UnmarshalBinary did not create a newSketch Sketch")
 
-	// If we re-use the same sketch, newSketch should be called
+	// The same holds when the receiver was already filled in
 	require.NoError(t, res.UnmarshalBinary(data))
+	require.EqualValues(t, uint32(1)<<res.p, res.m, "UnmarshalBinary did not create a newSketch Sketch")
+}
 
-	// Compare the "m" to make sure it was changed
-	require.NotEqual(t, 1, res.m, "UnmarshalBinary did not create a newSketch Sketch")
+// Tests that a failed Unmarshal leaves the receiver alone.
+func TestHLL_Unmarshal_ReceiverUnchangedOnError(t *testing.T) {
+	sk, err := NewSketch(14, true)
+	require.NoError(t, err)
+	for i := 0; i < 20; i++ {
+		sk.InsertHash(rand.Uint64())
+	}
+
+	data, err := sk.MarshalBinary()
+	require.NoError(t, err)
+
+	res := &Sketch{}
+	require.NoError(t, res.UnmarshalBinary(data))
+	want := res.Estimate()
+
+	err = res.UnmarshalBinary(data[:len(data)-3])
+	require.ErrorIs(t, err, ErrorTooShort)
+	require.EqualValues(t, want, res.Estimate())
+
+	// The receiver is not merely unchanged, it is still usable.
+	res.InsertHash(rand.Uint64())
+	require.GreaterOrEqual(t, res.Estimate(), want)
 }
 
 func TestHLL_Unmarshal_ErrorTooShort(t *testing.T) {
-	require.EqualValues(t, ErrorTooShort, (&Sketch{}).UnmarshalBinary(nil), "UnmarshalBinary(nil) should fail with ErrorTooShort")
+	require.ErrorIs(t, (&Sketch{}).UnmarshalBinary(nil), ErrorTooShort, "UnmarshalBinary(nil) should fail with ErrorTooShort")
 
 	b := []byte{
 		// precision:14, sparse:true, tmpSet:empty,
 		// sparseList:{count:1, last:0, sz:1, ...}
 		0x01, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x01, 0x7f,
+		0x00, 0x00, 0x00, 0x01, 0x00,
 	}
 	require.NoError(t, (&Sketch{}).UnmarshalBinary(b))
 	for i := 0; i < len(b)-1; i++ {
 		sk := &Sketch{}
 		err := sk.UnmarshalBinary(b[0:i])
-		require.EqualValues(t, ErrorTooShort, err, "should fail for incomplete bytes: i=%d", i)
+		require.ErrorIs(t, err, ErrorTooShort, "should fail for incomplete bytes: i=%d", i)
 	}
+
+	require.ErrorIs(t, (&Sketch{}).UnmarshalBinary(b[:4]), ErrorTooShort)
+}
+
+var unmarshalMalformedTests = []struct {
+	name    string
+	blob    []byte
+	wantErr error
+}{
+	{
+		name:    "dense unknown version",
+		blob:    []byte{0x63, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00},
+		wantErr: ErrorInvalidVersion,
+	},
+	{
+		name:    "sparse unknown version",
+		blob:    []byte{0x63, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorInvalidVersion,
+	},
+	{
+		name:    "precision too small",
+		blob:    []byte{0x02, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorInvalidPrecision,
+	},
+	{
+		name:    "precision too large",
+		blob:    []byte{0x02, 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorInvalidPrecision,
+	},
+	{
+		name:    "tmp set count exceeds input",
+		blob:    []byte{0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorTooShort,
+	},
+	{
+		name:    "tmp set count overflows",
+		blob:    []byte{0x02, 0x0e, 0x00, 0x01, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorTooShort,
+	},
+	{
+		name:    "dense register count does not match m",
+		blob:    []byte{0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name:    "dense registers truncated",
+		blob:    []byte{0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x01, 0x02, 0x03},
+		wantErr: ErrorTooShort,
+	},
+	{
+		name:    "v1 dense registers truncated",
+		blob:    []byte{0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11},
+		wantErr: ErrorTooShort,
+	},
+	{
+		name: "compressed list size exceeds input",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x7f, 0xff, 0xff, 0xff,
+		},
+		wantErr: ErrorTooShort,
+	},
+	{
+		name: "compressed list varint does not terminate",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x80,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "v1 sparse control",
+		blob: []byte{
+			0x01, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00,
+		},
+		wantErr: nil,
+	},
+	{
+		name: "compressed list count too large",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list count past the sparse limit",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list count exceeds decoded entries",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list zero delta after the first entry",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x02,
+			0x00, 0x00, 0x00, 0x03, 0x02, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list delta wraps uint32",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03,
+			0x00, 0x00, 0x00, 0x06, 0xd1, 0xff, 0xff, 0xff,
+			0x0f, 0x32,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list varint longer than five bytes",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02,
+			0x00, 0x00, 0x00, 0x07, 0x82, 0x80, 0x80, 0x80,
+			0x80, 0x80, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list varint does not fit in 32 bits",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x05, 0x80, 0x80, 0x80, 0x80,
+			0x10,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list varint not minimally encoded",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x02, 0x80, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list first delta zero",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00,
+		},
+		wantErr: nil,
+	},
+	{
+		name: "sparse payload with trailing bytes",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "v2 dense payload with trailing bytes",
+		blob: []byte{
+			0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "v1 dense payload with trailing bytes",
+		blob: []byte{
+			0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "compressed list last does not match the deltas",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05,
+			0x00, 0x00, 0x00, 0x01, 0x02,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "sparse list key out of range",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff,
+			0x00, 0x00, 0x00, 0x05, 0xff, 0xff, 0xff, 0xff,
+			0x0f,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "tmp set key out of range",
+		blob: []byte{
+			0x02, 0x0e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+			0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name:    "unknown sparse flag",
+		blob:    []byte{0x02, 0x0e, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name:    "v2 with a non zero bias",
+		blob:    []byte{0x02, 0x0e, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "v1 dense bias out of range",
+		blob: []byte{
+			0x01, 0x04, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+	{
+		name: "dense register out of range",
+		blob: []byte{
+			0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+			0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		wantErr: ErrorInvalidData,
+	},
+}
+
+func TestHLL_Unmarshal_Malformed(t *testing.T) {
+	for _, tt := range unmarshalMalformedTests {
+		t.Run(tt.name, func(t *testing.T) {
+			sk := &Sketch{}
+			var err error
+			require.NotPanics(t, func() { err = sk.UnmarshalBinary(tt.blob) })
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func FuzzUnmarshalBinary(f *testing.F) {
+	for _, precision := range []uint8{4, 14} {
+		for _, sparse := range []bool{true, false} {
+			sk, err := NewSketch(precision, sparse)
+			require.NoError(f, err)
+			for i := 0; i < 10; i++ {
+				sk.InsertHash(rand.Uint64())
+			}
+			data, err := sk.MarshalBinary()
+			require.NoError(f, err)
+			f.Add(data)
+		}
+	}
+	for _, tt := range unmarshalMalformedTests {
+		f.Add(tt.blob)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		sk, err := NewSketch(14, true)
+		require.NoError(t, err)
+
+		if err := sk.UnmarshalBinary(data); err != nil {
+			require.True(t,
+				errors.Is(err, ErrorTooShort) ||
+					errors.Is(err, ErrorInvalidData) ||
+					errors.Is(err, ErrorInvalidVersion) ||
+					errors.Is(err, ErrorInvalidPrecision),
+				"unexpected error: %v", err)
+			// A rejected blob leaves the receiver as it was, and usable.
+			sk.InsertHash(rand.Uint64())
+			sk.Estimate()
+			return
+		}
+
+		sk.Estimate()
+		require.NoError(t, sk.Merge(sk.Clone()))
+
+		out, err := sk.MarshalBinary()
+		require.NoError(t, err)
+		var res Sketch
+		require.NoError(t, res.UnmarshalBinary(out))
+		require.EqualValues(t, sk.Estimate(), res.Estimate())
+	})
+}
+
+func TestHLL_Unmarshal_V2_CopiesInput(t *testing.T) {
+	sk, err := NewSketch(16, false)
+	require.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		sk.InsertHash(uint64(rand.Int()))
+	}
+
+	data, err := sk.MarshalBinary()
+	require.NoError(t, err)
+
+	res := &Sketch{}
+	require.NoError(t, res.UnmarshalBinary(data))
+	want := res.Estimate()
+
+	for i := range data {
+		data[i] = 0xff
+	}
+	require.EqualValues(t, want, res.Estimate())
 }
 
 func TestHLL_AppendBinary(t *testing.T) {
@@ -485,6 +837,89 @@ func Benchmark_HLL_Marshal(b *testing.B) {
 	}
 	run(16, true)
 	run(16, false)
+}
+
+func Benchmark_UnmarshalBinary(b *testing.B) {
+	run := func(name string, sparse bool) {
+		b.Run(name, func(b *testing.B) {
+			sk, _ := NewSketch(16, sparse)
+			for i := 0; i < 1000; i++ {
+				sk.InsertHash(rand.Uint64())
+			}
+			data, err := sk.MarshalBinary()
+			require.NoError(b, err)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sk := &Sketch{}
+				_ = sk.UnmarshalBinary(data)
+			}
+		})
+	}
+	run("sparse", true)
+	run("dense", false)
+
+	b.Run("sparse-large", func(b *testing.B) {
+		sk, _ := NewSketch(16, true)
+		for sk.sparse() && sk.sparseList.Len() <= int(3*(uint32(1)<<16)/4) {
+			sk.InsertHash(rand.Uint64())
+		}
+		require.True(b, sk.sparse())
+		data, err := sk.MarshalBinary()
+		require.NoError(b, err)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			sk := &Sketch{}
+			_ = sk.UnmarshalBinary(data)
+		}
+	})
+}
+
+// The compressed list decoder rejects a zero delta after the first entry, so
+// mergeSparse has to emit every key at most once even when the tmp set and the
+// sparse list overlap.
+func TestHLL_MergeSparse_NoZeroDeltas(t *testing.T) {
+	sk, err := NewSketch(14, true)
+	require.NoError(t, err)
+
+	keys := make([]uint32, 100)
+	for i := range keys {
+		keys[i] = encodeHash(rand.Uint64(), sk.p, pp)
+		sk.tmpSet.add(keys[i])
+	}
+	sk.mergeSparse()
+
+	// Overlap the tmp set with the merged list, and add some fresh keys.
+	for i := 0; i < len(keys); i += 2 {
+		sk.tmpSet.add(keys[i])
+	}
+	for i := 0; i < 50; i++ {
+		sk.tmpSet.add(encodeHash(rand.Uint64(), sk.p, pp))
+	}
+	sk.mergeSparse()
+
+	var entries uint32
+	for i := 0; i < len(sk.sparseList.b); {
+		x, next, ok := sk.sparseList.b.decode(i)
+		require.True(t, ok, "varint at offset %d is malformed", i)
+		i = next
+		if entries > 0 {
+			require.NotZero(t, x, "delta %d is 0", entries)
+		}
+		entries++
+	}
+	require.EqualValues(t, sk.sparseList.count, entries)
+
+	// A duplicate or out of order key would encode as a wrapped delta that
+	// UnmarshalBinary rejects, so the merged list has to survive a round trip.
+	data, err := sk.MarshalBinary()
+	require.NoError(t, err)
+	var res Sketch
+	require.NoError(t, res.UnmarshalBinary(data))
+	require.EqualValues(t, sk.Estimate(), res.Estimate())
 }
 
 func TestHLL_Clone(t *testing.T) {

--- a/sparse.go
+++ b/sparse.go
@@ -1,6 +1,7 @@
 package hyperloglog
 
 import (
+	"fmt"
 	"math/bits"
 	"slices"
 
@@ -35,6 +36,15 @@ func decodeHash(k uint32, p, pp uint8) (uint32, uint8) {
 		r = uint8(bits.LeadingZeros64(uint64(k<<(32-pp+p-1))) - 31) // -32 + 1
 	}
 	return getIndex(k, p, pp), r
+}
+
+// checkSparseKey requires p to have passed checkPrecision.
+func checkSparseKey(k uint32, p uint8) error {
+	maxRho := maxRho(p)
+	if _, r := decodeHash(k, p, pp); r > maxRho {
+		return fmt.Errorf("hyperloglog: sparse key %#08x decodes to rho %d, max %d: %w", k, r, maxRho, ErrorInvalidData)
+	}
+	return nil
 }
 
 type set struct {


### PR DESCRIPTION
## Summary

Hardens `UnmarshalBinary` against corrupt or attacker-controlled input while keeping the change focused on serialization.

Decoding now validates the complete payload before replacing the receiver. Failed decodes leave the existing sketch unchanged and successful version 2 decodes copy register data instead of retaining the caller's buffer.

## What changed

- Reject unknown versions, unsupported precisions, invalid sparse keys/registers, inconsistent counts and lengths, malformed/non-minimal varints, wrapped or non-increasing deltas, and trailing bytes.
- Add `ErrorInvalidVersion`, `ErrorInvalidPrecision`, and `ErrorInvalidData` sentinel errors.
- Wrap `ErrorTooShort` with contextual errors; callers should use `errors.Is`.
- Validate compressed-list `count`, `last`, and stream contents before committing decoded state.
- Keep sparse merging compatible with the stricter decoder by ensuring it never emits zero deltas.
- Document the binary format and validation contract.

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=1 ./...`
- `go test -run '^$' -fuzz '^FuzzUnmarshalBinary$' -fuzztime=15s` — 4.59M executions, no failures

The branch is rebased onto the current `main` and the unrelated estimator, merge API, beta lookup, hashing, README release-note, and general benchmark changes from the original proposal have been removed.