### PR TITLE
docs: fix project name reference, spelling, and period in Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,6 +1,6 @@
 ## How to Contribute
 
-👍🎉 First of all, thank you for your interest in Axiom-node! We'd love to accept your patches and contributions! 🎉👍
+👍🎉 First of all, thank you for your interest in hyperloglog! We'd love to accept your patches and contributions! 🎉👍
 
 This project accepts contributions. In order to contribute, you should pay attention to a few guidelines:
 
@@ -33,10 +33,10 @@ go test -run Example -v
 
 3. Go makes it very simple to ensure properly formatted code, so always run `go fmt` on your code before committing it.
 
-4. Do your best to have [well-formated commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+4. Do your best to have [well-formatted commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 for each change. This provides consistency throughout the project and ensures that commit messages are able to be formatted properly by various git tools.
 
-5. Finally, push the commits to your fork and submit a [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
+5. Finally, push the commits to your fork and submit a [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 
 ### Once you've filed the PR:
 


### PR DESCRIPTION
## Description
This PR fixes typos and project name reference in `Contributing.md`.

## Details
1. Updated project name reference (`Axiom-node` -> `hyperloglog`).
2. Fixed spelling typo (`well-formated` -> `well-formatted`).
3. Added missing trailing period to step 5.