### PR TITLE
Fix unbounded sparse growth, a uint32 underflow in Estimate, and benchmark measurement

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -17,7 +17,10 @@ const (
 )
 
 // Sketch is a HyperLogLog estimator. Do not copy one after first use; use
-// Clone. Its zero value is empty and initializes on insertion or merge.
+// Clone. Its zero value is empty and initializes on insertion or merge: a zero
+// value first used with Insert or InsertHash takes New's configuration
+// (precision 14, sparse), while a zero value first used with Merge adopts the
+// other sketch's precision and representation.
 type Sketch struct {
 	p          uint8
 	m          uint32
@@ -204,7 +207,7 @@ func (sk *Sketch) Estimate() uint64 {
 	}
 	if sk.sparse() {
 		sk.mergeSparse()
-		return uint64(linearCount(mp, mp-sk.sparseList.count))
+		return uint64(linearCount(mp, mp-min(sk.sparseList.count, mp-1)))
 	}
 
 	sum, ez := sumAndZeros(sk.regs)
@@ -259,6 +262,9 @@ func (sk *Sketch) mergeSparse() {
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
 //
+// An uninitialized (zero value) Sketch has no encoding: its precision is 0, so
+// MarshalBinary returns an error wrapping ErrorInvalidPrecision.
+//
 // When the result will be appended to another buffer, consider using
 // AppendBinary to avoid additional allocations and copying.
 func (sk *Sketch) MarshalBinary() (data []byte, err error) {
@@ -266,6 +272,11 @@ func (sk *Sketch) MarshalBinary() (data []byte, err error) {
 }
 
 // AppendBinary implements the encoding.BinaryAppender interface.
+//
+// An uninitialized (zero value) Sketch has no encoding: its precision is 0, so
+// AppendBinary returns an error wrapping ErrorInvalidPrecision and leaves the
+// caller's buffer unmodified.
+//
 // UnmarshalBinary requires the encoding to be the entire buffer it is handed
 // and rejects trailing bytes with ErrorInvalidData. A caller appending a Sketch
 // into a larger buffer must frame the record itself; the number of bytes
@@ -332,7 +343,8 @@ var ErrorTooShort = errors.New("too short binary")
 var ErrorInvalidVersion = errors.New("unknown serialization version")
 
 // ErrorInvalidPrecision is returned unwrapped by NewSketch, and wrapped by
-// UnmarshalBinary, when the precision is outside the supported range.
+// UnmarshalBinary, MarshalBinary and AppendBinary, when the precision is
+// outside the supported range.
 var ErrorInvalidPrecision = errors.New("p has to be >= 4 and <= 18")
 
 // ErrorInvalidData is returned by UnmarshalBinary when the binary is long
@@ -362,6 +374,10 @@ var ErrorPrecisionMismatch = errors.New("precisions must be equal")
 // value, a uint32 big endian size sz, and sz bytes of a delta varint stream
 // whose final byte must have its high bit clear. The tmp set keys may appear in
 // any order.
+//
+// Version 2 pins the hash function to MetroHash64 with seed 1337 and the sparse
+// precision pp to 25. Sparse keys and dense registers are only meaningful under
+// those two constants, so changing either requires a new version byte.
 //
 // The version 2 dense payload is a uint32 big endian register count, which
 // must equal m = 1<<p, followed by m register bytes. In the version 1 dense

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -207,7 +207,15 @@ func (sk *Sketch) Estimate() uint64 {
 	}
 	if sk.sparse() {
 		sk.mergeSparse()
-		return uint64(linearCount(mp, mp-min(sk.sparseList.count, mp-1)))
+		// mergeSparse drains tmpSet into sparseList without consulting
+		// maybeToNormal, whose threshold only ever fires on insertion. Without
+		// this check a caller alternating small batches of Insert with
+		// Estimate keeps the sparse list growing past m forever.
+		if uint32(sk.sparseList.Len()) > sk.m {
+			sk.toNormal()
+		} else {
+			return uint64(linearCount(mp, mp-min(sk.sparseList.count, mp-1)))
+		}
 	}
 
 	sum, ez := sumAndZeros(sk.regs)

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -1129,12 +1129,12 @@ func Benchmark_Size_New_Sparse(b *testing.B) {
 
 func Benchmark_Insert(b *testing.B) {
 	sk := New16NoSparse()
-	value := []byte("benchmark")
+	blobs := genData(1 << 16)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		sk.Insert(value)
+		sk.Insert(blobs[i&(len(blobs)-1)])
 	}
 }
 

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -1104,9 +1104,12 @@ func benchmarkAdd(b *testing.B, sk *Sketch, n int) {
 		blobs = benchdata[n]
 	}
 
+	p, sparse := sk.p, sk.sparse()
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		*sk = *newSketchNoError(p, sparse)
 		for j := 0; j < len(blobs); j++ {
 			sk.Insert(blobs[j])
 		}
@@ -1175,14 +1178,21 @@ func randStr(n int) string {
 	return fmt.Sprintf("a%d %d", i, n)
 }
 
-func benchmark(precision uint8, n int) {
+func benchmark(b *testing.B, precision uint8) {
+	n := b.N
 	hll, _ := NewSketch(precision, true)
 
-	for i := 0; i < n; i++ {
-		s := []byte(randStr(i))
+	values := make([][]byte, n)
+	for i := range values {
+		values[i] = []byte(randStr(i))
+	}
+
+	b.ResetTimer()
+	for _, s := range values {
 		hll.Insert(s)
 		hll.Insert(s)
 	}
+	b.StopTimer()
 
 	e := hll.Estimate()
 	var percentErr = func(est uint64) float64 {
@@ -1195,32 +1205,32 @@ func benchmark(precision uint8, n int) {
 
 func BenchmarkHll4(b *testing.B) {
 	fmt.Println("")
-	benchmark(4, b.N)
+	benchmark(b, 4)
 }
 
 func BenchmarkHll6(b *testing.B) {
 	fmt.Println("")
-	benchmark(6, b.N)
+	benchmark(b, 6)
 }
 
 func BenchmarkHll8(b *testing.B) {
 	fmt.Println("")
-	benchmark(8, b.N)
+	benchmark(b, 8)
 }
 
 func BenchmarkHll10(b *testing.B) {
 	fmt.Println("")
-	benchmark(10, b.N)
+	benchmark(b, 10)
 }
 
 func BenchmarkHll14(b *testing.B) {
 	fmt.Println("")
-	benchmark(14, b.N)
+	benchmark(b, 14)
 }
 
 func BenchmarkHll16(b *testing.B) {
 	fmt.Println("")
-	benchmark(16, b.N)
+	benchmark(b, 16)
 }
 
 func BenchmarkZipf(b *testing.B) {


### PR DESCRIPTION
Three commits from a whole-project GoLegends review (`/goreview:goreview --fix`), plus one root-cause fix found while verifying the review's own findings.

## 1. Unbounded sparse growth in `Estimate` (`5491bb3`)

The significant one, and it was not on any judge's list.

`maybeToNormal` is the only place a sparse sketch converts to dense, and its threshold only fires on insertion. But `Estimate` calls `mergeSparse()` unconditionally, draining `tmpSet` into `sparseList` with **no conversion check**. So a caller alternating batches of fewer than `m/100` `Insert`s with `Estimate` grows the sparse list forever — no crafted input, pure public API:

```go
for { sk.Insert(...) /* fewer than m/100 keys */; sk.Estimate() }
```

Measured at `p=14`, where dense costs a flat 16 KiB:

| distinct | still sparse | sparse bytes | vs dense |
|---|---|---|---|
| 16,200 | yes | 32,262 | 2.0× |
| 64,800 | yes | 122,086 | 7.5× |
| 259,200 | yes | 417,416 | 25.5× |
| 1,036,800 | yes | 1,168,556 | 71.3× |

Still climbing at 1M distinct. It is also quadratic in time, since every `Estimate` re-merges the whole list — that probe ran in **25.4s before, 2.1s after**.

The fix reuses `maybeToNormal`'s exact threshold. Note `compressedList.Len()` returns `len(v.b)`, the varint stream's *byte* length rather than an entry count, so the threshold is "convert once the sparse encoding costs more than the dense one" — the right economics, and the existing idiom.

Estimates are unchanged: interleaving `Estimate` with `Insert` now yields bit-identical results to not interleaving (−0.94% at n=50k, +0.98% at n=200k, both arms equal).

## 2. `uint32` underflow in `Estimate`'s sparse branch (`5718075`)

`UnmarshalBinary` bounds the decoded list count below `mp` and the tmp set at `m` **separately**, but `mergeSparse` unions them, so `sparseList.count` can reach `(mp-1) + m` and `mp - count` wraps. Verified on darwin/arm64:

```
count=33554432  v=0           -> +Inf     -> uint64 = 18446744073709551615
count=33554433  v=4294967295  -> -1.63e8  -> uint64 = 0
```

Both conversions are implementation-dependent per the Go spec, so the returned estimate is garbage that differs by architecture. Clamped with `min(count, mp-1)`; every `count < mp` is bit-identical. Commit 1 independently closes the last path here, so this is now defence in depth.

## 3. Documentation and benchmark fixes (`5718075`, `afc1d95`)

- `MarshalBinary`/`AppendBinary` reject an uninitialized sketch with a wrapped `ErrorInvalidPrecision` — previously undocumented on both the methods and the sentinel.
- Version 2 pins MetroHash64 seed 1337 and `pp = 25`; changing either requires a new version byte.
- A zero-value `Sketch` takes `New`'s precision on `InsertHash` but the other sketch's precision on `Merge`.
- `BenchmarkHll4`–`BenchmarkHll16` timed `fmt.Sprintf`, the RNG, and `fmt.Printf` inside the measured region, so fixture construction dominated `Insert`.
- `benchmarkAdd` re-inserted the same blobs into an already saturated sketch on every `b.N` pass; it now rebuilds per iteration.
- `Benchmark_Insert` inserted one constant value, keeping a single register hot in L1; it now indexes distinct blobs by a power-of-two mask.

## Verification

`gofmt -l`, `go build ./...`, `go vet ./...`, and `go test -count=1 ./...` all clean at each commit.

## Not addressed here

- Three `external-evidence` findings need benchstat numbers rather than code: decode-validation cost for `Benchmark_UnmarshalBinary`, the break-even for the `100` flush factor and `4x` capacity multiplier, and `-benchmem` backing the `AppendBinary` allocation claim.
- A lead not yet verified: an accepted 24-byte v2 blob with `p=4` and all 16 registers at `maxRho` may drive `est` past `MaxUint64` at `hyperloglog.go:217` — the same float-to-uint64 class as #2, on the dense path.
- No regression test guards the sparse-growth invariant; nothing in the existing suite caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)