### PR TITLE
docs: fix H1 heading level and fork clone URL placeholder in Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,4 +1,4 @@
-## How to Contribute
+# How to Contribute
 
 👍🎉 First of all, thank you for your interest in hyperloglog! We'd love to accept your patches and contributions! 🎉👍
 
@@ -15,7 +15,7 @@ When reporting a bug, please try and provide as much context as possible such as
 [Fork](https://github.com/axiomhq/hyperloglog.git), then clone this repository:
 
 ```
-git clone https://github.com/axiomhq/hyperloglog.git
+git clone https://github.com/<your-username>/hyperloglog.git
 cd hyperloglog
 
 # Run formatting, linting, tests, and a build


### PR DESCRIPTION
## Description
This PR fixes the top-level H1 document header level and git clone URL username placeholder in `Contributing.md`.

## Details
1. Changed section level (`## How to Contribute` $\to$ `# How to Contribute`).
2. Replaced upstream clone URL with fork placeholder (`axiomhq` $\to$ `<your-username>`).